### PR TITLE
[Test] Devise ログイン機能の request
  spec を追加

### DIFF
--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "Users::Sessions", type: :request do
+  let(:user) do
+    User.create!(
+      email: "test@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  let(:valid_params) do
+    { user: { email: "test@example.com", password: "password123" } }
+  end
+
+  let(:invalid_params) do
+    { user: { email: "test@example.com", password: "wrongpassword" } }
+  end
+
+  describe "GET /users/sign_in" do
+    it "ログイン画面が表示される" do
+      get new_user_session_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "未ログイン時のアクセス制限" do
+    it "GET /users/edit にアクセスすると /users/sign_in にリダイレクトされる" do
+      get edit_user_registration_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "POST /users/sign_in" do
+    context "正しい資格情報の場合" do
+      before { user }
+
+      it "root_path にリダイレクトされる" do
+        post user_session_path, params: valid_params
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "ログイン後に GET /users/edit が 200 を返す" do
+        post user_session_path, params: valid_params
+        get edit_user_registration_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "誤ったパスワードの場合" do
+      before { user }
+
+      it "ログインに失敗する" do
+        post user_session_path, params: invalid_params
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "ログイン失敗後も GET /users/edit は /users/sign_in にリダイレクトされる" do
+        post user_session_path, params: invalid_params
+        get edit_user_registration_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
  Devise のログイン機能（セッション管理）を request spec で検証するテストを追加した。
  Devise は Issue #12 で導入済みのため、テストコードの追加のみで実装変更はなし。

  ## 関連 Issue
  closes #13

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | spec/requests/users/sessions_spec.rb | 追加 | Devise ログイン機能の動作を TDD で検証するため |

  ## 実装のポイント・判断理由
  - ログイン状態の確認は GET /users/edit へのアクセス可否で間接的に判定
  - Devise::Test::IntegrationHelpers の sign_in
  ヘルパーは不使用（ログイン処理自体をテストする目的のため）

  ## テスト計画
  - [x] GET /users/sign_in でログイン画面が表示される
  - [x] 未ログイン時に GET /users/edit が /users/sign_in にリダイレクトされる
  - [x] 正しい資格情報で POST /users/sign_in すると root_path にリダイレクトされる
  - [x] ログイン後に GET /users/edit が 200 を返す
  - [x] 誤ったパスワードで POST /users/sign_in すると 422 が返る
  - [x] ログイン失敗後も GET /users/edit は /users/sign_in にリダイレクトされる
  - [x] 全テスト通過（15 examples, 0 failures）
  - [x] RuboCop 通過

  ## 残件・TODO
  - なし