### PR TITLE
[Test] Devise パスワードリセット機能のテストを追加

### DIFF
--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -1,0 +1,182 @@
+require 'rails_helper'
+
+RSpec.describe "Users::Passwords", type: :request do
+  let(:user) do
+    User.create!(
+      email: "test@example.com",
+      password: "old_password123",
+      password_confirmation: "old_password123"
+    )
+  end
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  # GET /users/password/new
+  describe "GET /users/password/new" do
+    it "パスワード再設定画面が表示される（200）" do
+      get new_user_password_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("パスワードを忘れましたか？")
+    end
+  end
+
+  # POST /users/password
+  describe "POST /users/password" do
+    context "存在するメールアドレスの場合" do
+      it "メールが1通送信される" do
+        expect {
+          post user_password_path, params: { user: { email: user.email } }
+        }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+
+      it "リダイレクトされる（303）" do
+        post user_password_path, params: { user: { email: user.email } }
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it "メール本文に reset_password_token を含む URL が含まれる" do
+        post user_password_path, params: { user: { email: user.email } }
+
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.to).to eq([ user.email ])
+        expect(mail.subject).to include("パスワードの再設定")
+        expect(mail.body.encoded).to include("reset_password_token")
+        expect(mail.body.encoded).to include("example.com/users/password/edit")
+      end
+    end
+
+    context "存在しないメールアドレスの場合" do
+      it "例外にならない" do
+        expect {
+          post user_password_path, params: { user: { email: "nonexistent@example.com" } }
+        }.not_to raise_error
+      end
+
+      it "メールは送信されない" do
+        expect {
+          post user_password_path, params: { user: { email: "nonexistent@example.com" } }
+        }.not_to change { ActionMailer::Base.deliveries.count }
+      end
+
+      it "422 が返る" do
+        post user_password_path, params: { user: { email: "nonexistent@example.com" } }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  # GET /users/password/edit
+  describe "GET /users/password/edit" do
+    context "有効なトークンの場合" do
+      it "パスワード変更フォームが表示される（200）" do
+        raw_token = user.send_reset_password_instructions
+
+        get edit_user_password_path, params: { reset_password_token: raw_token }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("パスワードを変更")
+      end
+    end
+
+    context "無効なトークンの場合" do
+      it "フォームは表示されるがトークンエラー" do
+        get edit_user_password_path, params: { reset_password_token: "invalid_token" }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("パスワードを変更")
+      end
+    end
+  end
+
+  # PUT /users/password
+  describe "PUT /users/password" do
+    let(:raw_token) { user.send_reset_password_instructions }
+    let(:new_password) { "new_password123" }
+
+    context "有効なトークンと正しいパスワードの場合" do
+      it "パスワードが更新される" do
+        put user_password_path, params: {
+          user: {
+            reset_password_token: raw_token,
+            password: new_password,
+            password_confirmation: new_password
+          }
+        }
+
+        user.reload
+        expect(user.valid_password?(new_password)).to be true
+      end
+
+      it "新パスワードでログインできる" do
+        put user_password_path, params: {
+          user: {
+            reset_password_token: raw_token,
+            password: new_password,
+            password_confirmation: new_password
+          }
+        }
+
+        delete destroy_user_session_path
+
+        post user_session_path, params: {
+          user: { email: user.email, password: new_password }
+        }
+
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "旧パスワードではログインできない" do
+        old_password = "old_password123"
+
+        put user_password_path, params: {
+          user: {
+            reset_password_token: raw_token,
+            password: new_password,
+            password_confirmation: new_password
+          }
+        }
+
+        delete destroy_user_session_path
+
+        post user_session_path, params: {
+          user: { email: user.email, password: old_password }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("Eメールまたはパスワードが違います")
+      end
+    end
+
+    context "password_confirmation が不一致の場合" do
+      it "更新に失敗し 422 が返る" do
+        put user_password_path, params: {
+          user: {
+            reset_password_token: raw_token,
+            password: new_password,
+            password_confirmation: "different_password"
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("パスワード（確認用）とパスワードの入力が一致しません")
+      end
+    end
+
+    context "無効なトークンの場合" do
+      it "更新に失敗し 422 が返る" do
+        put user_password_path, params: {
+          user: {
+            reset_password_token: "invalid_token",
+            password: new_password,
+            password_confirmation: new_password
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("パスワードリセット用トークンは不正な値です")
+      end
+    end
+  end
+end


### PR DESCRIPTION
  ## 概要
  Devise Recoverable 機能のリクエストスペックを追加し、パスワードリセット機能の動作を検証できるようにしました。

  ## 関連 Issue
  closes #15

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `spec/requests/users/passwords_spec.rb` | 追加 | パスワードリセット機能のリクエストスペックを新規作成 |

  ## 実装のポイント・判断理由
  - 既存の Devise Recoverable 機能が正しく動作することを検証するテストを実装
  - 全10項目の受け入れ条件をカバーする14個のテストケースを作成
  - テスト環境ではメールは ActionMailer::Base.deliveries に蓄積される仕様を利用
  - 既存の sessions_spec.rb のパターンに従い、User.create! を使用してテストデータを作成

  ## テスト計画
  - [x] GET /users/password/new のテスト（200）
  - [x] POST /users/password のテスト（存在するメール・存在しないメール）
  - [x] GET /users/password/edit のテスト（有効なトークン・無効なトークン）
  - [x] PUT /users/password のテスト（パスワード更新・確認不一致・無効なトークン）
  - [x] 全テストが通過することを確認（14 examples, 0 failures）
  - [x] RuboCop が通過することを確認

  ## 残件・TODO
  - なしEOF
  )"




gh pr create --base main --title "[Test] Devise パスワードリセット機能のテストを追加" --body "$(cat <<'EOF'
  ## 概要
  Devise Recoverable 機能のリクエストスペックを追加し、パスワードリセット機能の動作を検証できるようにしました。

  ## 関連 Issue
  closes #15

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `spec/requests/users/passwords_spec.rb` | 追加 | パスワードリセット機能のリクエストスペックを新規作成 |

  ## 実装のポイント・判断理由
  - 既存の Devise Recoverable 機能が正しく動作することを検証するテストを実装
  - 全10項目の受け入れ条件をカバーする14個のテストケースを作成
  - テスト環境ではメールは ActionMailer::Base.deliveries に蓄積される仕様を利用
  - 既存の sessions_spec.rb のパターンに従い、User.create! を使用してテストデータを作成

  ## テスト計画
  - [x] GET /users/password/new のテスト（200）
  - [x] POST /users/password のテスト（存在するメール・存在しないメール）
  - [x] GET /users/password/edit のテスト（有効なトークン・無効なトークン）
  - [x] PUT /users/password のテスト（パスワード更新・確認不一致・無効なトークン）
  - [x] 全テストが通過することを確認（14 examples, 0 failures）
  - [x] RuboCop が通過することを確認

  ## 残件・TODO
  - なし