### PR TITLE
[Feature] Seeds::Allクラスで全マスタを一括管理

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,23 +13,6 @@ require_relative 'seeds/genres'
 require_relative 'seeds/mood_tags'
 require_relative 'seeds/meal_candidates'
 require_relative 'seeds/point_rules'
+require_relative 'seeds/all'
 
-puts 'Seeding HareTags...'
-Seeds::HareTags.call
-puts "  ✓ #{HareTag.count} HareTags created"
-
-puts 'Seeding Genres...'
-Seeds::Genres.call
-puts "  ✓ #{Genre.count} Genres created"
-
-puts 'Seeding MoodTags...'
-Seeds::MoodTags.call
-puts "  ✓ #{MoodTag.count} MoodTags created"
-
-puts 'Seeding MealCandidates...'
-Seeds::MealCandidates.call
-puts "  ✓ #{MealCandidate.count} MealCandidates created"
-
-puts 'Seeding PointRules...'
-Seeds::PointRules.call
-puts "  ✓ #{PointRule.count} PointRules created"
+Seeds::All.call

--- a/db/seeds/all.rb
+++ b/db/seeds/all.rb
@@ -1,0 +1,25 @@
+module Seeds
+  class All
+    def self.call
+      puts 'Seeding HareTags...'
+      Seeds::HareTags.call
+      puts "  ✓ #{HareTag.count} HareTags created"
+
+      puts 'Seeding Genres...'
+      Seeds::Genres.call
+      puts "  ✓ #{Genre.count} Genres created"
+
+      puts 'Seeding MoodTags...'
+      Seeds::MoodTags.call
+      puts "  ✓ #{MoodTag.count} MoodTags created"
+
+      puts 'Seeding MealCandidates...'
+      Seeds::MealCandidates.call
+      puts "  ✓ #{MealCandidate.count} MealCandidates created"
+
+      puts 'Seeding PointRules...'
+      Seeds::PointRules.call
+      puts "  ✓ #{PointRule.count} PointRules created"
+    end
+  end
+end

--- a/spec/models/seeds/all_seed_spec.rb
+++ b/spec/models/seeds/all_seed_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+require_relative '../../../db/seeds/hare_tags'
+require_relative '../../../db/seeds/genres'
+require_relative '../../../db/seeds/mood_tags'
+require_relative '../../../db/seeds/meal_candidates'
+require_relative '../../../db/seeds/point_rules'
+require_relative '../../../db/seeds/all'
+
+RSpec.describe Seeds::All do
+  describe '.call' do
+    context '空のデータベースから実行した場合' do
+      before do
+        HareTag.destroy_all
+        Genre.destroy_all
+        MoodTag.destroy_all
+        MealCandidate.destroy_all
+        PointRule.destroy_all
+      end
+
+      it '全てのマスタデータが作成されること' do
+        expect { described_class.call }.to change {
+          [ HareTag.count, Genre.count, MoodTag.count, MealCandidate.count, PointRule.count ]
+        }
+      end
+
+      it 'HareTagが作成されること' do
+        expect { described_class.call }.to change(HareTag, :count).from(0)
+      end
+
+      it 'Genreが作成されること' do
+        expect { described_class.call }.to change(Genre, :count).from(0)
+      end
+
+      it 'MoodTagが作成されること' do
+        expect { described_class.call }.to change(MoodTag, :count).from(0)
+      end
+
+      it 'MealCandidateが作成されること' do
+        expect { described_class.call }.to change(MealCandidate, :count).from(0)
+      end
+
+      it 'PointRuleが作成されること' do
+        expect { described_class.call }.to change(PointRule, :count).from(0)
+      end
+    end
+
+    context '冪等性の確認' do
+      before do
+        HareTag.destroy_all
+        Genre.destroy_all
+        MoodTag.destroy_all
+        MealCandidate.destroy_all
+        PointRule.destroy_all
+        described_class.call # 1回目実行
+      end
+
+      it '2回実行してもレコード数が変わらないこと' do
+        hare_tag_count = HareTag.count
+        genre_count = Genre.count
+        mood_tag_count = MoodTag.count
+        meal_candidate_count = MealCandidate.count
+        point_rule_count = PointRule.count
+
+        described_class.call # 2回目実行
+
+        expect(HareTag.count).to eq(hare_tag_count)
+        expect(Genre.count).to eq(genre_count)
+        expect(MoodTag.count).to eq(mood_tag_count)
+        expect(MealCandidate.count).to eq(meal_candidate_count)
+        expect(PointRule.count).to eq(point_rule_count)
+      end
+
+      it '3回実行してもエラーにならないこと' do
+        expect { described_class.call }.not_to raise_error
+        expect { described_class.call }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- Seeds::Allクラスを作成し、全マスタデータを一括管理
- db:seed で4種類のマスタが一括投入される
- 冪等性を確保し、テストで検証

## 関連 Issue
closes #21

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `db/seeds/all.rb` | 追加 | Seeds::Allクラスで全seedを一元管理 |
| `db/seeds.rb` | 編集 | Seeds::All.callで一括呼び出しに変更 |
| `spec/models/seeds/all_seed_spec.rb` | 追加 | 全体の冪等性テスト |

## 実装のポイント・判断理由

### Seeds::Allクラスの作成
全seedを一箇所で管理することで、以下のメリットを実現：
- **テストしやすい**: Seeds::All.callをテストすれば全体の動作を検証できる
- **保守しやすい**: seedの実行順序を1箇所で管理
- **拡張しやすい**: 新しいseedを追加する際、Seeds::Allに1行追加するだけ

### 冪等性の確保
全てのseedで `find_or_create_by!` を使用しているため、複数回実行しても：
- レコード数が増えない
- エラーにならない
- 既存データを破壊しない

### テスト設計
- 空のデータベースから実行した場合のテスト（5 examples）
- 冪等性の確認テスト（2 examples）
- 3回実行してもエラーにならないことの検証

## 実行結果

### テスト結果
```
8 examples, 0 failures
```

### seed実行結果（1回目）
```
Seeding HareTags...
  ✓ 10 HareTags created
Seeding Genres...
  ✓ 8 Genres created
Seeding MoodTags...
  ✓ 6 MoodTags created
Seeding MealCandidates...
  ✓ 40 MealCandidates created
Seeding PointRules...
  ✓ 3 PointRules created
```

### seed実行結果（2回目・冪等性確認）
```
Seeding HareTags...
  ✓ 10 HareTags created  (件数変化なし)
Seeding Genres...
  ✓ 8 Genres created     (件数変化なし)
Seeding MoodTags...
  ✓ 6 MoodTags created   (件数変化なし)
Seeding MealCandidates...
  ✓ 40 MealCandidates created  (件数変化なし)
Seeding PointRules...
  ✓ 3 PointRules created (件数変化なし)
```

## テスト計画
- [x] Seeds::All.callで全マスタが作成されること
- [x] 2回実行しても件数が増えないこと（冪等性）
- [x] 3回実行してもエラーにならないこと
- [x] RuboCop通過

## 残件・TODO
- なし