### PR TITLE
[Feature] HareEntry 削除機能を実装

### DIFF
--- a/app/controllers/hare_entries_controller.rb
+++ b/app/controllers/hare_entries_controller.rb
@@ -1,6 +1,6 @@
 class HareEntriesController < ApplicationController
     before_action :authenticate_user!
-    before_action :set_hare_entry, only: [ :show, :edit, :update ]
+    before_action :set_hare_entry, only: [ :show, :edit, :update, :destroy ]
 
     def index
       @hare_entries = current_user.hare_entries.order(created_at: :desc)
@@ -32,6 +32,11 @@ class HareEntriesController < ApplicationController
       else
         render :edit, status: :unprocessable_entity
       end
+    end
+
+    def destroy
+      @hare_entry.destroy
+      redirect_to hare_entries_path, notice: "ハレの記録を削除しました"
     end
 
     private

--- a/app/views/hare_entries/show.html.erb
+++ b/app/views/hare_entries/show.html.erb
@@ -25,6 +25,12 @@
 
         <div class="card-actions justify-end mt-6">
           <%= link_to "編集", edit_hare_entry_path(@hare_entry), class: "btn btn-primary" %>
+            <%= button_to "削除",
+              hare_entry_path(@hare_entry),
+              method: :delete,
+              data: { turbo_confirm: "本当に削除しますか？" },
+              class: "btn btn-error" 
+              %>
           <%= link_to "一覧に戻る", hare_entries_path, class: "btn btn-outline" %>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "home#index"
 
-  resources :hare_entries, only: [ :index, :show, :new, :create, :edit, :update ]
+    resources :hare_entries, only: [ :index, :show, :new, :create, :edit, :update, :destroy ]
 end


### PR DESCRIPTION
  ## 概要
  - HareEntry の削除機能を実装しました
  - 自分の投稿のみ削除可能、他人の投稿は 404 エラーになります
  - 削除後は一覧ページにリダイレクトされます

  ## 関連 Issue
  closes #26

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `spec/requests/hare_entries_spec.rb` | 編集 | 削除機能の request spec を追加 |
  | `config/routes.rb` | 編集 | resources の only に :destroy を追加 |
  | `app/controllers/hare_entries_controller.rb` | 編集 | destroy アクションを実装、before_action に :destroy を追加 |
  | `app/views/hare_entries/show.html.erb` | 編集 | 詳細ページに削除ボタンを追加 |

  ## 実装のポイント・判断理由
  - **認可チェック:** `current_user.hare_entries.find` によるスコープベースの認可チェックで、他人の投稿は自動的に 404 になる
  - **削除確認:** `data: { turbo_confirm: }` で誤操作を防止
  - **button_to の採用:** DELETE メソッドを使用するため、`link_to` ではなく `button_to` を使用
  - **ボタンスタイル:** 危険な操作を視覚的に示すため `btn-error` クラス（赤色）を使用

  ## テスト計画
  - [x] request spec で削除機能をテスト（未ログイン、自分の投稿、他人の投稿、存在しない ID）
  - [x] RSpec 全テスト通過確認（53 examples, 0 failures）
  - [x] RuboCop 構文チェック通過（no offenses detected）

  ## 残件・TODO
  - なし