### PR TITLE
[Feature] タグ付け：投稿編集時にタグを更新できるようにする（TDD）

### DIFF
--- a/app/controllers/hare_entries_controller.rb
+++ b/app/controllers/hare_entries_controller.rb
@@ -26,12 +26,14 @@ class HareEntriesController < ApplicationController
     end
 
     def edit
+      @hare_tags = HareTag.active.sorted
     end
 
     def update
       if @hare_entry.update(hare_entry_params)
         redirect_to hare_entry_path(@hare_entry), notice: "ハレの記録を更新しました"
       else
+        @hare_tags = HareTag.active.sorted
         render :edit, status: :unprocessable_entity
       end
     end

--- a/app/views/hare_entries/edit.html.erb
+++ b/app/views/hare_entries/edit.html.erb
@@ -5,7 +5,7 @@
       <%= link_to "← 詳細に戻る", hare_entry_path(@hare_entry), class: "text-primary hover:underline" %>
     </div>
     <h1 class="text-2xl font-bold mb-6">ハレの記録を編集</h1>
-    <%= render 'form', hare_entry: @hare_entry, submit_label: "更新する", cancel_path: hare_entry_path(@hare_entry) %>
+    <%= render 'form', hare_entry: @hare_entry, submit_label: "更新する", cancel_path: hare_entry_path(@hare_entry), hare_tags: @hare_tags %>
   </div>
 </main>
 <%= render 'shared/footer' %>


### PR DESCRIPTION
## 概要
- HareEntry の編集画面でタグの追加・削除・変更ができるようになりました
- Issue #28 の対応

## 関連 Issue
closes #28

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `spec/requests/hare_entries_spec.rb` | 編集 | タグ更新のテストケースを追加 |
| `app/controllers/hare_entries_controller.rb` | 編集 | edit/updateアクションで@hare_tagsを設定 |
| `app/views/hare_entries/edit.html.erb` | 編集 | フォームパーシャルにhare_tagsを渡す |

## 実装のポイント
- `edit`アクションで `@hare_tags = HareTag.active.sorted` を取得
- `update`アクションの失敗時にも `@hare_tags` を設定（再表示時にタグを表示）
- `edit.html.erb` で `hare_tags: @hare_tags` をパーシャルに渡す
- `hare_tag_ids` は既に strong parameters で許可済みのため、そのまま更新可能
- `collection_check_boxes` が現在の `hare_tag_ids` を自動的に選択済みとして表示

## テスト計画
- [x] GET /hare_entries/:id/edit でタグチェックボックスが表示される
- [x] 現在紐付いているタグが選択済みとして表示される
- [x] PATCH /hare_entries/:id でタグが更新される（差し替え）
- [x] タグを全て外すことができる
- [x] 全197テストが成功
- [x] RuboCop チェック通過

## 残件・TODO
- なし