### PR TITLE
[Feature] 投稿更新時のポイント再計算機能実装

### DIFF
--- a/app/controllers/hare_entries_controller.rb
+++ b/app/controllers/hare_entries_controller.rb
@@ -32,6 +32,7 @@ class HareEntriesController < ApplicationController
 
     def update
       if @hare_entry.update(hare_entry_params)
+        PointRecalculationService.call(@hare_entry)
         redirect_to hare_entry_path(@hare_entry), notice: "ハレの記録を更新しました"
       else
         @hare_tags = HareTag.active.sorted

--- a/app/services/point_recalculation_service.rb
+++ b/app/services/point_recalculation_service.rb
@@ -1,0 +1,8 @@
+class PointRecalculationService
+  def self.call(hare_entry)
+    ActiveRecord::Base.transaction do
+      hare_entry.point_transactions.destroy_all
+      PointAwardService.call(hare_entry)
+    end
+  end
+end

--- a/spec/services/point_recalculation_service_spec.rb
+++ b/spec/services/point_recalculation_service_spec.rb
@@ -1,0 +1,172 @@
+require 'rails_helper'
+
+RSpec.describe PointRecalculationService, type: :service do
+  let(:user) { create(:user) }
+  let(:hare_entry) { create(:hare_entry, user: user, occurred_on: Date.new(2026, 2, 10)) }
+
+  before do
+    # テストデータを完全にクリア
+    PointTransaction.destroy_all
+    PointRule.destroy_all
+
+    # テスト用のルール（1つのみ）
+    create(:point_rule, key: 'post_base', label: 'ハレ投稿', points: 1, priority: 1, is_active: true)
+  end
+
+  describe '.call' do
+    context '既存のポイント履歴がある状態で再計算する場合' do
+      before do
+        # 初回作成時のポイント付与（タグなし: 1pt）
+        PointAwardService.call(hare_entry)
+      end
+
+      it '既存の point_transactions が削除される' do
+        expect {
+          PointRecalculationService.call(hare_entry)
+        }.not_to change { PointTransaction.count }
+        # 削除→再作成で件数は変わらない
+      end
+
+      it '最新の条件でポイントが再計算される' do
+        # タグを追加（ただし post_base ルールのみなのでポイントは変わらない）
+        tag = create(:hare_tag)
+        hare_entry.hare_tags << tag
+
+        PointRecalculationService.call(hare_entry)
+
+        # post_base (1pt) のみ
+        expect(hare_entry.reload.awarded_points).to eq(1)
+        expect(hare_entry.point_transactions.count).to eq(1)
+      end
+
+      it 'awarded_points が正しく計算される' do
+        # 再計算を実行
+        PointRecalculationService.call(hare_entry)
+
+        # post_base (1pt) が適用される
+        expect(hare_entry.reload.awarded_points).to eq(1)
+      end
+    end
+
+    context 'occurred_on を変更した場合' do
+      let(:old_date) { Date.new(2026, 2, 10) }
+      let(:new_date) { Date.new(2026, 2, 9) }
+
+      before do
+        # このテスト用にトランザクションをクリア
+        user.point_transactions.destroy_all
+        hare_entry.update!(occurred_on: old_date)
+        PointAwardService.call(hare_entry)
+      end
+
+      it '新しい日付で point_transactions が作成される' do
+        hare_entry.update!(occurred_on: new_date)
+        PointRecalculationService.call(hare_entry)
+
+        transactions = hare_entry.reload.point_transactions
+        expect(transactions.pluck(:awarded_on).uniq).to eq([ new_date ])
+      end
+
+      it '旧日付の履歴は削除され、新日付の履歴が作成される' do
+        old_count = user.point_transactions.where(awarded_on: old_date).count
+        expect(old_count).to eq(1)
+
+        hare_entry.update!(occurred_on: new_date)
+        PointRecalculationService.call(hare_entry)
+
+        # 旧日付の履歴が減る
+        expect(user.point_transactions.where(awarded_on: old_date).count).to eq(0)
+        # 新日付の履歴が増える
+        expect(user.point_transactions.where(awarded_on: new_date).count).to eq(1)
+      end
+    end
+
+    context '日次上限を考慮した再計算' do
+      let(:occurred_on) { Date.new(2026, 2, 10) }
+
+      before do
+        hare_entry.update!(occurred_on: occurred_on)
+      end
+
+      it '日次上限内で再計算される' do
+        # 別の投稿2つで2pt消費済み
+        other_entry1 = create(:hare_entry, user: user, occurred_on: occurred_on)
+        PointAwardService.call(other_entry1)
+        other_entry2 = create(:hare_entry, user: user, occurred_on: occurred_on)
+        PointAwardService.call(other_entry2)
+
+        expect(user.point_transactions.where(awarded_on: occurred_on).sum(:points)).to eq(2)
+
+        # この投稿は残り1ptのみ付与可能
+        hare_entry.update!(occurred_on: occurred_on)
+        PointRecalculationService.call(hare_entry)
+
+        # post_base (1pt) が付与される（上限3ptまで）
+        expect(hare_entry.reload.awarded_points).to eq(1)
+        expect(user.point_transactions.where(awarded_on: occurred_on).sum(:points)).to eq(3)
+      end
+
+      it '日次上限を超えない' do
+        # すでに3pt消費済み
+        3.times do
+          entry = create(:hare_entry, user: user, occurred_on: occurred_on)
+          PointAwardService.call(entry)
+        end
+
+        expect(user.point_transactions.where(awarded_on: occurred_on).sum(:points)).to eq(3)
+
+        # この投稿を再計算しても上限を超えない
+        PointRecalculationService.call(hare_entry)
+
+        expect(user.point_transactions.where(awarded_on: occurred_on).sum(:points)).to eq(3)
+      end
+    end
+
+    context 'トランザクションのロールバック' do
+      it 'PointAwardService でエラーが発生した場合、削除もロールバックされる' do
+        PointAwardService.call(hare_entry)
+        initial_count = hare_entry.point_transactions.count
+
+        # PointAwardService でエラーを発生させる
+        allow(PointAwardService).to receive(:call).and_raise(StandardError, 'テストエラー')
+
+        expect {
+          PointRecalculationService.call(hare_entry)
+        }.to raise_error(StandardError, 'テストエラー')
+
+        # トランザクションがロールバックされるため、削除も取り消される
+        expect(hare_entry.point_transactions.count).to eq(initial_count)
+      end
+    end
+
+    context 'タグの追加・削除による再計算' do
+      let(:tag1) { create(:hare_tag, key: 'tag1') }
+      let(:tag2) { create(:hare_tag, key: 'tag2') }
+
+      it 'タグを追加しても再計算が正しく動作する' do
+        PointAwardService.call(hare_entry)
+        expect(hare_entry.reload.awarded_points).to eq(1)
+
+        hare_entry.hare_tags << tag1
+        PointRecalculationService.call(hare_entry)
+
+        # post_base ルールのみなのでポイントは1ptのまま
+        expect(hare_entry.reload.awarded_points).to eq(1)
+        expect(hare_entry.point_transactions.count).to eq(1)
+      end
+
+      it 'タグを削除しても再計算が正しく動作する' do
+        hare_entry.hare_tags << tag1
+        PointAwardService.call(hare_entry)
+        expect(hare_entry.reload.awarded_points).to eq(1)
+
+        hare_entry.hare_tags.clear
+        PointRecalculationService.call(hare_entry)
+
+        # post_base ルールのみなのでポイントは1ptのまま
+        expect(hare_entry.reload.awarded_points).to eq(1)
+        expect(hare_entry.point_transactions.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
  ## 概要

  投稿更新時（タグ追加/削除、日付変更など）にポイントを再計算する機能を実装しました。

  ## 関連 Issue

  closes #31

  ## 変更ファイル一覧

  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `app/services/point_recalculation_service.rb` | 追加 | 投稿更新時のポイント再計算サービス |
  | `app/controllers/hare_entries_controller.rb` | 修正 | update アクションで再計算サービスを呼び出し |
  | `spec/services/point_recalculation_service_spec.rb` | 追加 | PointRecalculationService のユニットテスト |
  | `spec/requests/hare_entries_spec.rb` | 修正 | 投稿更新時のポイント再計算の統合テスト |

  ## 実装のポイント

  ### PointRecalculationService の設計

  - **削除→再付与方式を採用**: 差分計算よりシンプルで保守性が高い
  - **トランザクションで整合性を保証**: 削除と再付与を「セット」で実行
  - **PointAwardService を再利用**: DRY原則に従い、作成時と同じロジックを使用

  ### 処理フロー

  1. トランザクション開始
  2. 既存 point_transactions を削除
  3. PointAwardService で再計算
    - 最新の条件（タグ、日付）で評価
    - 日次上限を再チェック
    - 新しい point_transactions を作成
  4. awarded_points キャッシュ更新
  5. コミット（成功時）/ ロールバック（失敗時）

  ### コントローラーでの呼び出し

  ```ruby
  def update
    if @hare_entry.update(hare_entry_params)
      PointRecalculationService.call(@hare_entry)  # ← 再計算
      redirect_to hare_entry_path(@hare_entry), notice: "更新しました"
    end
  end

  テスト計画

  サービススペック（10 examples）

  - ✅ 既存履歴の削除→再計算
  - ✅ タグ追加/削除での再計算
  - ✅ occurred_on 変更時の挙動
  - ✅ 日次上限の考慮
  - ✅ トランザクションのロールバック

  リクエストスペック（5 examples）

  - ✅ タグ追加時のポイント再計算
  - ✅ タグ削除時の再計算
  - ✅ occurred_on 変更時の履歴移動

  テスト結果

  244 examples, 0 failures, 3 pending

  残件・TODO

  - なし（MVP として完成）

  備考

  - Issue #30 で実装した PointAwardService を再利用
  - 日次上限（3pt/日）を更新時も厳守
  - トランザクションで削除と再付与の原子性を保証