### PR TITLE
[Fix] compose.ymlのDATABASE_URL環境変数を削除してテスト環境の問題を修正

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -35,7 +35,6 @@ services:
       COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
       APP_UID: "${APP_UID:-1000}"
       APP_GID: "${APP_GID:-1000}"
-      DATABASE_URL: "postgres://postgres:password@db:5432/kehare_cho_development"
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## 概要
`compose.yml`の`DATABASE_URL`環境変数を削除し、`database.yml`の設定を使用するように修正しました。

## 関連 Issue
closes #81

## 問題の背景
- RSpecテスト実行時に12件のテストが失敗していた
- 原因: `compose.yml`で`DATABASE_URL`が`kehare_cho_development`固定だった
- Railsは`DATABASE_URL`環境変数 > `database.yml`の優先順位で動作する
- `RAILS_ENV=test`を設定しても、データベース接続先が変わらなかった

## 変更内容

### 修正ファイル
| ファイル | 種別 | 変更内容 |
|---------|------|---------|
| `compose.yml` | 修正 | `DATABASE_URL`環境変数を削除 |

### 修正前
```yaml
environment:
  DATABASE_URL: "postgres://postgres:password@db:5432/kehare_cho_development"
```

### 修正後
```yaml
environment:
  # DATABASE_URL を削除（database.yml の設定を使用）
```

## 動作確認

### テスト結果
```
修正前: 283 examples, 12 failures
修正後: 283 examples, 0 failures, 3 pending
```

### 環境別接続確認
| 環境 | 接続先DB | 確認結果 |
|------|----------|----------|
| development | `kehare_cho_development` | ✅ 正常 |
| test | `kehare_cho_test` | ✅ 正常 |
| production | `ENV["DATABASE_URL"]` | ✅ 影響なし |

## 期待される効果
- ✅ `RAILS_ENV`に応じて自動的に正しいデータベースに接続される
- ✅ テスト実行時に特別なコマンドは不要になる
- ✅ 環境間の切り替えが正しく動作する
- ✅ 本番環境（Render）には影響なし（`database.yml`で`ENV["DATABASE_URL"]`を使用）

## テスト計画
- [x] 開発環境でRailsが起動することを確認
- [x] 開発環境で正しいDBに接続されることを確認
- [x] テスト環境で全テストが通ることを確認
- [x] 本番環境の設定に影響がないことを確認

## 残件・TODO
なし