### PR TITLE
実装: 献立検索ログ保存機能（Issue #39）

### DIFF
--- a/app/controllers/meal_searches_controller.rb
+++ b/app/controllers/meal_searches_controller.rb
@@ -18,6 +18,7 @@ class MealSearchesController < ApplicationController
     genre_id = params[:genre_id]
     picker = MealCandidatePicker.new(genre_id: genre_id)
     candidates = picker.pick
+    current_user.meal_searches.create!(genre_id: genre_id, presented_candidate_names: candidates.map(&:name))
     session[:meal_candidates] = candidates.map(&:id)
     redirect_to meal_searches_path
   end

--- a/app/models/meal_search.rb
+++ b/app/models/meal_search.rb
@@ -1,0 +1,9 @@
+class MealSearch < ApplicationRecord
+  belongs_to :user
+
+  serialize :presented_candidate_names, coder: JSON
+  validates :user, presence: true
+
+  enum :meal_mode, { ke: 0, hare: 1 }
+  enum :cook_context, { self_cook: 0, eat_out: 1, ready_made: 2 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   has_many :hare_entries, dependent: :destroy
   has_many :point_transactions, dependent: :destroy
+  has_many :meal_searches, dependent: :destroy
 
   def monthly_points
     current_month_range = Time.zone.now.beginning_of_month.to_date..Time.zone.now.end_of_month.to_date

--- a/db/migrate/20260212080546_create_meal_searches.rb
+++ b/db/migrate/20260212080546_create_meal_searches.rb
@@ -1,0 +1,15 @@
+class CreateMealSearches < ActiveRecord::Migration[8.1]
+  def change
+    create_table :meal_searches do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :meal_mode
+      t.integer :cook_context
+      t.integer :required_minutes
+      t.integer :genre_id
+      t.integer :mood_id
+      t.text :presented_candidate_names
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_10_051447) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_12_080546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -72,6 +72,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_10_051447) do
     t.index ["position"], name: "index_meal_candidates_on_position"
   end
 
+  create_table "meal_searches", force: :cascade do |t|
+    t.integer "cook_context"
+    t.datetime "created_at", null: false
+    t.integer "genre_id"
+    t.integer "meal_mode"
+    t.integer "mood_id"
+    t.text "presented_candidate_names"
+    t.integer "required_minutes"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_meal_searches_on_user_id"
+  end
+
   create_table "mood_tags", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.boolean "is_active", default: true, null: false
@@ -127,6 +140,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_10_051447) do
   add_foreign_key "hare_entry_tags", "hare_entries"
   add_foreign_key "hare_entry_tags", "hare_tags"
   add_foreign_key "meal_candidates", "genres"
+  add_foreign_key "meal_searches", "users"
   add_foreign_key "point_transactions", "hare_entries"
   add_foreign_key "point_transactions", "point_rules"
   add_foreign_key "point_transactions", "users"

--- a/spec/factories/meal_searches.rb
+++ b/spec/factories/meal_searches.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :meal_search do
+    association :user
+    meal_mode { 0 }
+    cook_context { 0 }
+    required_minutes { 20 }
+    genre_id { 1 }
+    mood_id { 1 }
+    presented_candidate_names { [ '唐揚げ', 'カレー', '餃子' ] }
+  end
+end

--- a/spec/models/meal_search_spec.rb
+++ b/spec/models/meal_search_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe MealSearch, type: :model do
+  describe 'アソシエーション' do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe 'バリデーション' do
+    it { is_expected.to validate_presence_of(:user) }
+  end
+
+  describe 'serialize' do
+    let(:user) { create(:user) }
+    let(:meal_search) { described_class.new(user: user, genre_id: 1) }
+
+    it 'presented_candidate_names に配列を保存できる' do
+      names = [ '唐揚げ', 'カレー', '餃子' ]
+      meal_search.presented_candidate_names = names
+      meal_search.save!
+
+      # データベースから再読み込み
+      saved_search = described_class.find(meal_search.id)
+      expect(saved_search.presented_candidate_names).to eq(names)
+    end
+
+    it 'presented_candidate_names に空配列を保存できる' do
+      meal_search.presented_candidate_names = []
+      meal_search.save!
+
+      saved_search = described_class.find(meal_search.id)
+      expect(saved_search.presented_candidate_names).to eq([])
+    end
+
+    it 'presented_candidate_names が nil の場合も保存できる' do
+      meal_search.presented_candidate_names = nil
+      meal_search.save!
+
+      saved_search = described_class.find(meal_search.id)
+      expect(saved_search.presented_candidate_names).to be_nil
+    end
+  end
+
+  describe 'enum' do
+    describe 'meal_mode' do
+      it { is_expected.to define_enum_for(:meal_mode).with_values(ke: 0, hare: 1) }
+    end
+
+    describe 'cook_context' do
+      it { is_expected.to define_enum_for(:cook_context).with_values(self_cook: 0, eat_out: 1, ready_made: 2) }
+    end
+  end
+end

--- a/spec/requests/meal_searches_spec.rb
+++ b/spec/requests/meal_searches_spec.rb
@@ -81,6 +81,41 @@ RSpec.describe "MealSearches", type: :request do
         expect(session[:meal_candidates].size).to eq(3)
       end
 
+      it "検索ログ（MealSearch）が作成される" do
+        expect {
+          post meal_searches_path, params: { genre_id: genre.id }
+        }.to change(MealSearch, :count).by(1)
+      end
+
+      it "検索ログが current_user に紐づく" do
+        post meal_searches_path, params: { genre_id: genre.id }
+        meal_search = MealSearch.last
+        expect(meal_search.user).to eq(user)
+      end
+
+      it "検索ログに genre_id が保存される" do
+        post meal_searches_path, params: { genre_id: genre.id }
+        meal_search = MealSearch.last
+        expect(meal_search.genre_id).to eq(genre.id)
+      end
+
+      it "検索ログに presented_candidate_names が配列で保存される" do
+        post meal_searches_path, params: { genre_id: genre.id }
+        meal_search = MealSearch.last
+        expect(meal_search.presented_candidate_names).to be_an(Array)
+        expect(meal_search.presented_candidate_names.size).to eq(3)
+      end
+
+      it "検索ログの presented_candidate_names が候補の name を含む" do
+        post meal_searches_path, params: { genre_id: genre.id }
+        meal_search = MealSearch.last
+        candidates = MealCandidate.where(id: session[:meal_candidates])
+
+        candidates.each do |candidate|
+          expect(meal_search.presented_candidate_names).to include(candidate.name)
+        end
+      end
+
       context "ジャンル一致候補が3件未満の場合" do
         let(:other_genre) { create(:genre, key: 'other', label: 'その他') }
 


### PR DESCRIPTION
  ## 概要
  - 献立検索時にログを保存する機能を実装
  - ユーザーが過去の検索条件を振り返れるようにする

  ## 関連 Issue
  closes #39

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `db/migrate/20260212080546_create_meal_searches.rb` | 追加 | meal_searches テーブル作成 |
  | `app/models/meal_search.rb` | 追加 | MealSearch モデル定義 |
  | `app/models/user.rb` | 編集 | has_many :meal_searches 追加 |
  | `app/controllers/meal_searches_controller.rb` | 編集 | create アクションにログ保存処理追加 |
  | `spec/models/meal_search_spec.rb` | 編集 | MealSearch モデルのテスト追加 |
  | `spec/requests/meal_searches_spec.rb` | 編集 | ログ保存のリクエストテスト追加 |
  | `spec/factories/meal_searches.rb` | 追加 | MealSearch の Factory 定義 |
  | `db/schema.rb` | 自動更新 | マイグレーション実行結果 |

  ## 実装のポイント
  - **serialize で JSON 配列保存:** `presented_candidate_names` を JSON 配列として保存
  - **処理順序の最適化:** ログ保存 → セッション保存の順で実行（ログ保存失敗時にセッションも保存しない）
  - **enum 定義:** `meal_mode`, `cook_context` を enum で定義（将来の拡張用）
  - **Rails 8.1 対応:** enum の新しい書き方 `enum :column_name, { ... }` を使用

  ## テスト計画
  - [x] Model Spec: アソシエーション、バリデーション、serialize、enum
  - [x] Request Spec: ログ作成、user紐付け、保存内容の検証
  - [x] RuboCop チェック通過
  - [x] 全テスト通過（343 examples, 0 failures）

  ## 残件・TODO
  - なし