### PR TITLE
実装: ホームナビゲーション導線追加（Issue #42）

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -37,6 +37,8 @@
           <div class="card-actions justify-end mt-4 gap-2">
             <%= link_to "ハレを記録する", new_hare_entry_path, class: "btn btn-primary" %>
             <%= link_to "献立相談", new_meal_search_path, class: "btn btn-secondary" %>
+            <%= link_to "ハレ一覧", hare_entries_path, class: "btn btn-outline btn-primary" %>
+            <%= link_to "ログ一覧", meal_searches_path, class: "btn btn-outline btn-secondary" %>
           </div>
         </div>
       </div>

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -208,6 +208,32 @@ RSpec.describe "Home", type: :request do
         get root_path
         expect(response.body).not_to include("新規登録")
       end
+
+      context 'ナビゲーションリンク表示' do
+        before do
+          get root_path
+        end
+
+        it '「ハレを記録する」リンクが存在する' do
+          expect(response.body).to include('ハレを記録する')
+          expect(response.body).to include(new_hare_entry_path)
+        end
+
+        it '「献立相談」リンクが存在する' do
+          expect(response.body).to include('献立相談')
+          expect(response.body).to include(new_meal_search_path)
+        end
+
+        it '「ハレ一覧」リンクが存在する' do
+          expect(response.body).to include('ハレ一覧')
+          expect(response.body).to include(hare_entries_path)
+        end
+
+        it '「ログ一覧」リンクが存在する' do
+          expect(response.body).to include('ログ一覧')
+          expect(response.body).to include(meal_searches_path)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
  ## 概要
  ホーム画面から主要機能へ1クリックでアクセスできるように、ナビゲーションリンクを追加しました。

  ## 関連 Issue
  closes #42

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `app/views/home/index.html.erb` | 変更 | ハレ一覧・ログ一覧リンクを追加 |
  | `spec/requests/home_spec.rb` | 変更 | ナビゲーションリンクのテストを追加 |

  ## 実装のポイント

  ### 追加したリンク
  - **ハレ一覧** (`/hare_entries`) - 過去のハレ投稿を確認
  - **ログ一覧** (`/meal_searches`) - 過去の献立相談履歴を確認

  ### UI 設計
  - 新規作成リンク: `btn btn-primary` / `btn btn-secondary`（目立つ）
  - 一覧表示リンク: `btn btn-outline btn-primary` / `btn btn-outline btn-secondary`（控えめ）
  - 視覚的な優先度を区別することで、ユーザーの主要アクション（新規作成）を強調

  ### テスト
  - request spec で全4つのリンク（既存2つ + 新規2つ）の存在を確認
  - リンクテキストとパスの両方をテスト

  ## テスト計画
  - [x] 全テストパス（22 examples, 0 failures）
  - [x] RuboCop チェックパス（no offenses detected）

  ## 残件・TODO
  なし