### PR TITLE
実装: プライバシーポリシー・利用規約ページ

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,7 @@
+class PagesController < ApplicationController
+  def privacy_policy
+  end
+
+  def terms
+  end
+end

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,0 +1,81 @@
+<%= render "shared/header" %>
+
+<div class="container mx-auto p-4 max-w-4xl">
+  <h1 class="text-3xl font-bold mb-6">プライバシーポリシー</h1>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>サービス概要</h2>
+      <p>ケハレ帖（以下「本サービス」）は、日常の食事に「小さなハレ」を足す行動を記録・可視化するサービスです。本プライバシーポリシーは、本サービスにおける個人情報の取り扱いについて説明するものです。</p>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>収集する情報</h2>
+      <p>本サービスでは、以下の情報を収集します：</p>
+      <ul>
+        <li>メールアドレス（アカウント登録時に必須）</li>
+        <li>ニックネーム（任意設定）</li>
+        <li>ハレ投稿の内容（投稿日、本文、タグ情報）</li>
+        <li>献立検索の履歴（検索キーワード）</li>
+        <li>ポイント・レベルなどのゲーミフィケーション情報</li>
+      </ul>
+      <p>※本サービスは学習目的で作成されたものであり、実際の個人情報を入力しないでください。</p>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>情報の利用目的</h2>
+      <p>収集した情報は、以下の目的で利用します：</p>
+      <ul>
+        <li>本サービスの提供・運営</li>
+        <li>ユーザー認証・アカウント管理</li>
+        <li>ユーザー体験の向上・機能改善</li>
+        <li>お問い合わせ対応</li>
+      </ul>
+      <p>これらの目的以外で、ユーザーの同意なく個人情報を利用することはありません。</p>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>情報の管理</h2>
+      <p>本サービスは、個人情報の漏洩、滅失、毀損を防止するため、適切なセキュリティ対策を講じます。ただし、本サービスは学習目的のアプリケーションであり、商用サービスと同等のセキュリティ水準は保証できません。</p>
+      <p>個人情報は、法令に基づく場合を除き、第三者に提供することはありません。</p>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>免責事項</h2>
+      <p>本サービスは学習目的で作成されたアプリケーションです。以下の点にご注意ください：</p>
+      <ul>
+        <li>サービスの継続性を保証するものではありません</li>
+        <li>データの永続性を保証するものではありません</li>
+        <li>予告なくサービスを終了する場合があります</li>
+      </ul>
+      <p>本サービスの利用によって生じた損害について、運営者は一切の責任を負いません。</p>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>プライバシーポリシーの変更</h2>
+      <p>本プライバシーポリシーは、法令の変更や本サービスの機能追加に応じて、予告なく変更することがあります。変更後のプライバシーポリシーは、本ページに掲載した時点で効力を生じるものとします。</p>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>お問い合わせ先</h2>
+      <p>本プライバシーポリシーに関するお問い合わせは、以下までご連絡ください：</p>
+      <p>ケハレ帖 運営チーム<br>
+      Email: （学習用アプリのため省略）</p>
+      <p class="text-sm text-gray-500 mt-4">制定日: 2026年2月13日</p>
+    </div>
+  </div>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,0 +1,93 @@
+<%= render "shared/header" %>
+
+<div class="container mx-auto p-4 max-w-4xl">
+  <h1 class="text-3xl font-bold mb-6">利用規約</h1>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>サービスの利用条件</h2>
+      <p>ケハレ帖（以下「本サービス」）をご利用いただくには、以下の条件に同意していただく必要があります：</p>
+      <ul>
+        <li>本規約の内容を理解し、遵守すること</li>
+        <li>本サービスが学習目的で作成されたアプリケーションであることを理解すること</li>
+        <li>実際の個人情報や機密情報を入力しないこと</li>
+        <li>18歳以上であること（または保護者の同意を得ていること）</li>
+      </ul>
+      <p>アカウント登録をもって、本規約に同意したものとみなします。</p>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>禁止事項</h2>
+      <p>本サービスの利用にあたり、以下の行為を禁止します：</p>
+      <ul>
+        <li>法令または公序良俗に違反する行為</li>
+        <li>他のユーザーや第三者の権利を侵害する行為</li>
+        <li>本サービスの運営を妨害する行為</li>
+        <li>不正アクセス、サーバーへの負荷をかける行為</li>
+        <li>本サービスの脆弱性を悪用する行為</li>
+        <li>複数アカウントの不正取得</li>
+        <li>虚偽の情報を登録する行為</li>
+        <li>本サービスを商用目的で利用する行為</li>
+      </ul>
+      <p>これらの禁止事項に違反した場合、アカウントの停止・削除を行う場合があります。</p>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>免責事項</h2>
+      <p>本サービスの利用に関して、以下の点をご理解ください：</p>
+      <ul>
+        <li>本サービスは学習目的で作成されており、商用サービスではありません</li>
+        <li>サービスの品質、正確性、完全性、有用性について保証するものではありません</li>
+        <li>サービスの中断、終了、データの消失等について一切の責任を負いません</li>
+        <li>本サービスの利用によって生じた損害について、運営者は一切の責任を負いません</li>
+        <li>外部サービス（Google検索など）へのリンクについて、その内容に責任を負いません</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>アカウントの管理</h2>
+      <p>ユーザーは、自己の責任においてアカウント情報（メールアドレス、パスワード）を管理するものとします。アカウント情報の管理不十分による損害について、運営者は一切の責任を負いません。</p>
+      <p>第三者によるアカウントの不正利用が判明した場合、速やかに運営者に連絡してください。</p>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>サービスの変更・終了</h2>
+      <p>運営者は、以下の権利を有します：</p>
+      <ul>
+        <li>本サービスの内容を予告なく変更すること</li>
+        <li>本サービスの全部または一部を予告なく停止・終了すること</li>
+        <li>本規約を予告なく変更すること</li>
+      </ul>
+      <p>これらの変更・終了によって生じた損害について、運営者は一切の責任を負いません。</p>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>準拠法・管轄裁判所</h2>
+      <p>本規約の解釈および適用は、日本法に準拠するものとします。</p>
+      <p>本サービスに関連して生じた紛争については、運営者の所在地を管轄する裁判所を専属的合意管轄裁判所とします。</p>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>お問い合わせ</h2>
+      <p>本規約に関するお問い合わせは、以下までご連絡ください：</p>
+      <p>ケハレ帖 運営チーム<br>
+      Email: （学習用アプリのため省略）</p>
+      <p class="text-sm text-gray-500 mt-4">制定日: 2026年2月13日<br>
+      最終更新日: 2026年2月13日</p>
+    </div>
+  </div>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,8 +2,9 @@
   text-base-content mt-8">
     <div>
       <p>
-        <%= link_to "プライバシーポリシー", "#", class: "link   
-  link-hover" %>
+        <%= link_to "プライバシーポリシー", privacy_policy_path, class: "link link-hover" %>
+        |
+        <%= link_to "利用規約", terms_path, class: "link link-hover" %>
       </p>
       <p>&copy; 2026 <%= t('app_name') %>. All rights
   reserved.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "privacy_policy", to: "pages#privacy_policy"
+  get "terms", to: "pages#terms"
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+RSpec.describe "Pages", type: :request do
+  describe "GET /privacy_policy" do
+    context '未ログイン時' do
+      it '正常にアクセスできる' do
+        get privacy_policy_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'プライバシーポリシーページが表示される' do
+        get privacy_policy_path
+        expect(response.body).to include('プライバシーポリシー')
+      end
+
+      it 'サービス概要が表示される' do
+        get privacy_policy_path
+        expect(response.body).to include('サービス概要')
+      end
+
+      it '収集する情報が表示される' do
+        get privacy_policy_path
+        expect(response.body).to include('収集する情報')
+      end
+
+      it '情報の利用目的が表示される' do
+        get privacy_policy_path
+        expect(response.body).to include('情報の利用目的')
+      end
+
+      it '情報の管理が表示される' do
+        get privacy_policy_path
+        expect(response.body).to include('情報の管理')
+      end
+
+      it '免責事項が表示される' do
+        get privacy_policy_path
+        expect(response.body).to include('免責事項')
+      end
+
+      it 'お問い合わせ先が表示される' do
+        get privacy_policy_path
+        expect(response.body).to include('お問い合わせ先')
+      end
+    end
+
+    context 'ログイン時' do
+      let(:user) { User.create!(email: 'test@example.com', password: 'password') }
+
+      before { sign_in user }
+
+      it '正常にアクセスできる' do
+        get privacy_policy_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'プライバシーポリシーページが表示される' do
+        get privacy_policy_path
+        expect(response.body).to include('プライバシーポリシー')
+      end
+    end
+  end
+
+  describe "GET /terms" do
+    context '未ログイン時' do
+      it '正常にアクセスできる' do
+        get terms_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it '利用規約ページが表示される' do
+        get terms_path
+        expect(response.body).to include('利用規約')
+      end
+
+      it 'サービスの利用条件が表示される' do
+        get terms_path
+        expect(response.body).to include('サービスの利用条件')
+      end
+
+      it '禁止事項が表示される' do
+        get terms_path
+        expect(response.body).to include('禁止事項')
+      end
+
+      it '免責事項が表示される' do
+        get terms_path
+        expect(response.body).to include('免責事項')
+      end
+
+      it 'アカウントの管理が表示される' do
+        get terms_path
+        expect(response.body).to include('アカウントの管理')
+      end
+
+      it 'サービスの変更・終了が表示される' do
+        get terms_path
+        expect(response.body).to include('サービスの変更・終了')
+      end
+
+      it '準拠法・管轄裁判所が表示される' do
+        get terms_path
+        expect(response.body).to include('準拠法・管轄裁判所')
+      end
+
+      it 'お問い合わせが表示される' do
+        get terms_path
+        expect(response.body).to include('お問い合わせ')
+      end
+    end
+
+    context 'ログイン時' do
+      let(:user) { User.create!(email: 'test@example.com', password: 'password') }
+
+      before { sign_in user }
+
+      it '正常にアクセスできる' do
+        get terms_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it '利用規約ページが表示される' do
+        get terms_path
+        expect(response.body).to include('利用規約')
+      end
+    end
+  end
+end


### PR DESCRIPTION
  プライバシーポリシーと利用規約のページを実装しました。

  ## 変更内容
  ### コントローラー
  - `PagesController` を作成（privacy_policy, terms アクション）
    - 認証不要（未ログインでもアクセス可能）
    - ビューを表示するだけ（ロジックなし）

  ### ビュー
  - `pages/privacy_policy.html.erb`: プライバシーポリシーページ
    - サービス概要、収集する情報、情報の利用目的、情報の管理、免責事項、プライバシーポリシーの変更、お問い合わせ先
  - `pages/terms.html.erb`: 利用規約ページ
    - サービスの利用条件、禁止事項、免責事項、アカウントの管理、サービスの変更・終了、準拠法・管轄裁判所、お問い合わせ

  ### ルーティング
  - `get 'privacy_policy', to: 'pages#privacy_policy'` を追加
  - `get 'terms', to: 'pages#terms'` を追加

  ### その他
  - フッターにプライバシーポリシーと利用規約のリンクを追加

  ## テスト
  - PagesController の全アクション（21例）
  - 未ログイン・ログイン両方でアクセス可能であることを確認
  - 全テスト 416 例が通過

  ## 変更ファイル一覧
  | ファイル | 種別 | 変更理由 |
  |---------|------|---------|
  | `app/controllers/pages_controller.rb` | 追加 | 静的ページ用コントローラー |
  | `app/views/pages/privacy_policy.html.erb` | 追加 | プライバシーポリシーページ |
  | `app/views/pages/terms.html.erb` | 追加 | 利用規約ページ |
  | `config/routes.rb` | 修正 | ルート追加 |
  | `app/views/shared/_footer.html.erb` | 修正 | リンク修正・追加 |
  | `spec/requests/pages_spec.rb` | 追加 | リクエストスペック |

  ## 実装のポイント
  - PagesController パターンを採用（複数の静的ページを1つのコントローラーで管理）
  - 認証不要とし、未ログインユーザーでもアクセス可能
  - 学習アプリのため、内容は仮テキスト（実際のサービスでは弁護士レビューが必要）
  - daisyUI の card と prose クラスを活用し、読みやすいレイアウトを実現

  ## 残件・TODO
  - なし