### PR TITLE
実装: 全体レイアウト統一・導線修正（Issue #97）

### DIFF
--- a/app/views/calendar/index.html.erb
+++ b/app/views/calendar/index.html.erb
@@ -1,6 +1,4 @@
-<%= render 'shared/header' %>
-
-<main class="container mx-auto px-4 py-8">
+<main>
   <h1 class="text-2xl font-bold mb-6">カレンダー</h1>
 
   <div class="overflow-x-auto">
@@ -15,5 +13,3 @@
     <% end %>
   </div>
 </main>
-
-<%= render 'shared/footer' %>

--- a/app/views/calendar/show.html.erb
+++ b/app/views/calendar/show.html.erb
@@ -1,6 +1,4 @@
-<%= render 'shared/header' %>
-
-  <main class="container mx-auto px-4 py-8">
+  <main>
     <h1 class="text-2xl font-bold mb-6">
       <%= @date.strftime("%Y年%m月%d日") %> のハレ投稿
     </h1>
@@ -46,5 +44,3 @@
     </div>
   <% end %>
   </main>
-
-  <%= render 'shared/footer' %>

--- a/app/views/hare_entries/edit.html.erb
+++ b/app/views/hare_entries/edit.html.erb
@@ -1,5 +1,4 @@
-<%= render 'shared/header' %>
-<main class="container mx-auto px-4 py-8">
+<main>
   <div class="max-w-2xl mx-auto">
     <div class="mb-4">
       <%= link_to "← 詳細に戻る", hare_entry_path(@hare_entry), class: "text-primary hover:underline" %>
@@ -8,4 +7,3 @@
     <%= render 'form', hare_entry: @hare_entry, submit_label: "更新する", cancel_path: hare_entry_path(@hare_entry), hare_tags: @hare_tags %>
   </div>
 </main>
-<%= render 'shared/footer' %>

--- a/app/views/hare_entries/index.html.erb
+++ b/app/views/hare_entries/index.html.erb
@@ -1,6 +1,4 @@
-<%= render 'shared/header' %>
-
-<main class="container mx-auto px-4 py-8">
+<main>
   <h1 class="text-2xl font-bold mb-6">ハレの記録</h1>
 
   <%# 今月のポイントとレベル表示 %>
@@ -42,5 +40,3 @@
     </div>
   <% end %>
 </main>
-
-<%= render 'shared/footer' %>

--- a/app/views/hare_entries/show.html.erb
+++ b/app/views/hare_entries/show.html.erb
@@ -1,6 +1,4 @@
-<%= render 'shared/header' %>
-
-<main class="container mx-auto px-4 py-8">
+<main>
   <div class="max-w-2xl mx-auto">
     <div class="mb-4">
       <%= link_to "← 一覧に戻る", hare_entries_path, class: "text-primary hover:underline" %>
@@ -37,5 +35,3 @@
     </div>
   </div>
 </main>
-
-<%= render 'shared/footer' %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,8 +1,6 @@
 <% if user_signed_in? %>
     <%# ログイン後のホーム画面 %>
-    <%= render 'shared/header' %>
-
-    <main class="container mx-auto px-4 py-8">
+    <main>
       <%# 今月のポイント表示 %>
       <div class="card bg-base-100 shadow-xl mb-6">
         <div class="card-body">
@@ -43,9 +41,8 @@
         </div>
       </div>
     </main>
-
-    <%= render 'shared/footer' %>
   <% else %>
+    <% content_for :hide_header do %>true<% end %>
     <%# 未ログイン時のLP %>
     <div class="min-h-screen bg-base-200 flex items-center      
   justify-center">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,8 +24,15 @@
   </head>
 
   <body>
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
-    <%= yield %>
+    <% if user_signed_in? && !content_for?(:hide_header) %>
+      <%= render 'shared/header' %>
+    <% end %>
+
+    <div class="container mx-auto px-4 py-6">
+      <%= render 'shared/flash' %>
+      <%= yield %>
+    </div>
+
+    <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |type, message| %>
+  <div class="alert alert-<%= type == 'notice' ? 'success' : 'error' %> mb-4">
+    <span><%= message %></span>
+  </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,7 +7,7 @@
         <li><%= link_to "ホーム", home_path, class: "btn btn-ghost btn-sm" %></li>
         <li><%= link_to "カレンダー", calendar_path, class: "btn btn-ghost btn-sm" %></li>
         <li><%= link_to "献立相談", new_meal_search_path, class: "btn btn-ghost btn-sm" %></li>
-        <li><button class="btn btn-ghost btn-sm" disabled>ハレ投稿</button></li>
+        <li><%= link_to "ハレ投稿", new_hare_entry_path, class: "btn btn-ghost btn-sm" %></li>
         <li><%= link_to "プロフィール", profile_path, class: "btn btn-ghost btn-sm" %></li>
         <li>
           <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-primary btn-sm" %>

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe "Home", type: :request do
         expect(response.body).to include("ログイン")
       end
 
-      it "ヘッダーとフッターは表示されない" do
+      it "ヘッダーは表示されないが、フッターは表示される" do
         get root_path
         expect(response.body).not_to include("ログアウト")
-        expect(response.body).not_to include("プライバシーポリシー")
+        expect(response.body).to include("プライバシーポリシー")
       end
     end
 

--- a/spec/requests/layouts_spec.rb
+++ b/spec/requests/layouts_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+
+RSpec.describe "共通レイアウト", type: :request do
+  let(:user) { create(:user) }
+
+  describe "ログイン済みユーザー" do
+    before { sign_in user }
+
+    context "全ページで共通要素が表示される" do
+      it "ホームページでヘッダーとフッターが表示される" do
+        get root_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("ホーム")
+        expect(response.body).to include("カレンダー")
+        expect(response.body).to include("献立相談")
+        expect(response.body).to include("ハレ投稿")
+        expect(response.body).to include("プロフィール")
+        expect(response.body).to include("ログアウト")
+        expect(response.body).to include("プライバシーポリシー")
+        expect(response.body).to include("利用規約")
+      end
+
+      it "ハレ一覧ページでヘッダーとフッターが表示される" do
+        get hare_entries_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("ホーム")
+        expect(response.body).to include("プライバシーポリシー")
+      end
+
+      it "カレンダーページでヘッダーとフッターが表示される" do
+        get calendar_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("ホーム")
+        expect(response.body).to include("プライバシーポリシー")
+      end
+
+      it "プロフィールページでヘッダーとフッターが表示される" do
+        get profile_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("ホーム")
+        expect(response.body).to include("プライバシーポリシー")
+      end
+    end
+
+    context "ヘッダーのナビゲーションリンク" do
+      it "「ハレ投稿」リンクが正しいパスを指している" do
+        get root_path
+        expect(response.body).to include('href="/hare_entries/new"')
+      end
+
+      it "「ホーム」リンクが正しいパスを指している" do
+        get hare_entries_path
+        expect(response.body).to include('href="/"')
+      end
+
+      it "「カレンダー」リンクが正しいパスを指している" do
+        get root_path
+        expect(response.body).to include('href="/calendar"')
+      end
+
+      it "「プロフィール」リンクが正しいパスを指している" do
+        get root_path
+        expect(response.body).to include('href="/profile"')
+      end
+    end
+  end
+
+  describe "未ログインユーザー" do
+    context "ホームページ（LP）" do
+      it "ヘッダーが表示されない" do
+        get root_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("ホーム")
+        expect(response.body).not_to include("カレンダー")
+        expect(response.body).not_to include("ハレ投稿")
+      end
+
+      it "フッターは表示される" do
+        get root_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("プライバシーポリシー")
+        expect(response.body).to include("利用規約")
+      end
+    end
+
+    context "ログインページ" do
+      it "ヘッダーが表示されない" do
+        get new_user_session_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("ホーム")
+        expect(response.body).not_to include("カレンダー")
+      end
+
+      it "フッターは表示される" do
+        get new_user_session_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("プライバシーポリシー")
+      end
+    end
+  end
+
+  describe "flashメッセージの表示" do
+    before { sign_in user }
+
+    context "ハレ投稿作成時の成功メッセージ" do
+      it "作成後のリダイレクトが正しく動作する" do
+        post hare_entries_path, params: {
+          hare_entry: {
+            body: "テスト投稿",
+            occurred_on: Date.current,
+            visibility: "private_post"
+          }
+        }
+        expect(response).to have_http_status(:found)
+        follow_redirect!
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "バリデーションエラー時のメッセージ" do
+      it "エラーメッセージが表示される" do
+        post hare_entries_path, params: {
+          hare_entry: {
+            body: "",  # 空欄でバリデーションエラー
+            occurred_on: Date.current,
+            visibility: "private_post"
+          }
+        }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("個のエラーが発生しました")
+        expect(response.body).to include("Bodyを入力してください")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
各ビューで個別にheader/footerをrenderしている状態を改善し、application.html.erbに統一してレイアウトの一貫性を確保しました。また、flashメッセージをdaisyUIのalertコンポーネントで表示するようにし、ヘッダーの「ハレ投稿」ボタンを有効化しました。

## 関連 Issue
closes #97

## 変更内容

### 1. Flash メッセージパーシャルの作成
- `app/views/shared/_flash.html.erb` を作成
- `notice` → `alert-success`、`alert` → `alert-error` のクラスマッピング
- daisyUI の alert コンポーネント構造を使用

### 2. application.html.erb の修正
- ログイン時のみヘッダー表示（`user_signed_in? && !content_for?(:hide_header)`）
- flash メッセージを `render 'shared/flash'` で統一表示
- フッターを全ページ共通で表示
- コンテンツエリアに `container mx-auto px-4 py-6` クラスを追加

### 3. ヘッダーの修正
- 「ハレ投稿」ボタンの `disabled` 属性を削除
- `link_to` ヘルパーで `new_hare_entry_path` にリンク

### 4. 各ビューから個別 render を削除
以下のファイルから `render 'shared/header'` と `render 'shared/footer'` を削除：
- `app/views/home/index.html.erb`（ログイン済み部分）
- `app/views/hare_entries/index.html.erb`
- `app/views/hare_entries/show.html.erb`
- `app/views/hare_entries/edit.html.erb`
- `app/views/calendar/show.html.erb`
- `app/views/calendar/index.html.erb`

### 5. 未ログイン LP のヘッダー制御
- `home/index.html.erb` の未ログイン部分に `content_for :hide_header` を追加
- フッターは未ログイン時も表示される

### 6. テストの追加・修正
- `spec/requests/layouts_spec.rb` を新規作成（14 examples）
  - 全ページで共通レイアウトの確認
  - ヘッダーナビゲーションリンクの確認
  - 未ログイン時のレイアウト確認
  - flash メッセージの表示確認
- `spec/requests/home_spec.rb` の修正
  - 未ログイン時のテスト：「フッターは表示される」に変更

## 実装のポイント

### content_for の活用
- ビュー側で `content_for :hide_header` を設定
- レイアウト側で `content_for?(:hide_header)` で存在チェック
- 特定ページでヘッダーを非表示にする柔軟な仕組み

### daisyUI alert コンポーネント
```erb
<% flash.each do |type, message| %>
  <div class="alert alert-<%= type == 'notice' ? 'success' : 'error' %> mb-4">
    <span><%= message %></span>
  </div>
<% end %>
```

### ヘッダー表示条件
```erb
<% if user_signed_in? && !content_for?(:hide_header) %>
  <%= render 'shared/header' %>
<% end %>
```

## テスト結果
```
430 examples, 0 failures, 3 pending
Line Coverage: 97.06%
```

## 残件・TODO
なし