### PR TITLE
[Feature] 使い方ページの新規作成

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,7 @@
 class PagesController < ApplicationController
+  def how_to_use
+  end
+
   def privacy_policy
   end
 

--- a/app/views/pages/how_to_use.html.erb
+++ b/app/views/pages/how_to_use.html.erb
@@ -1,0 +1,128 @@
+<%= render "shared/header" %>
+
+<div class="container mx-auto p-4 max-w-4xl">
+  <h1 class="text-3xl font-bold mb-6 text-center">ケハレ帖の使い方</h1>
+
+  <!-- 1. イントロ -->
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2 class="text-primary">今日のごはんに、小さなハレを。</h2>
+      <p>
+        「ケハレ帖」は、日常の食事に「小さな特別」を見つけて記録するアプリです。
+      </p>
+      <p>
+        <strong>ケ（褻）</strong>とは「日常」のこと。<br>
+        <strong>ハレ（晴れ）</strong>とは「特別な日」のこと。
+      </p>
+      <p>
+        毎日のごはんは「ケ」だけど、ちょっと工夫したり、いつもより美味しいものを選んだり。<br>
+        そんな<span class="text-primary font-bold">「小さなハレ」</span>を記録して、日常を楽しく振り返りましょう。
+      </p>
+    </div>
+  </div>
+
+  <!-- 2. 献立相談 -->
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>🍳 献立相談機能</h2>
+      <p>「今日は何を食べよう？」そんなときは、献立相談を使ってみましょう。</p>
+      <ol>
+        <li><strong>食事のジャンルを選ぶ</strong>：和食、洋食、中華など、気分に合わせて選択</li>
+        <li><strong>候補が3つ表示される</strong>：ランダムにおすすめの献立が提案されます</li>
+        <li><strong>気になったらGoogle検索へ</strong>：レシピを調べたり、お店を探したりできます</li>
+      </ol>
+      <p class="text-sm text-gray-600">
+        ※ レシピデータベースは持っていません。Google検索で自由に探してください。
+      </p>
+    </div>
+  </div>
+
+  <!-- 3. ハレ投稿 -->
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>✨ ハレ投稿機能</h2>
+      <p>「今日のごはん、ちょっと特別だったな」と思ったら、ハレ投稿で記録しましょう。</p>
+      <ol>
+        <li><strong>日付を選ぶ</strong>：今日のことでも、過去のことでもOK</li>
+        <li><strong>タグを選ぶ</strong>：「いつもより手間をかけた」「ちょっと贅沢した」など、ハレの種類を選択</li>
+        <li><strong>ひとことメモを書く</strong>：「久しぶりに魚を焼いた」「デザート付き」など、自由に記録</li>
+        <li><strong>投稿完了！</strong>：ポイントが貯まり、カレンダーにスタンプが付きます</li>
+      </ol>
+    </div>
+  </div>
+
+  <!-- 4. カレンダー -->
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>📅 カレンダー機能</h2>
+      <p>投稿したハレは、カレンダーでスタンプとして表示されます。</p>
+      <ul>
+        <li><strong>1か月の記録が一目で分かる</strong>：「今月は何回ハレがあったかな？」</li>
+        <li><strong>タグごとにスタンプが違う</strong>：手間をかけた日、贅沢した日が色分けされます</li>
+        <li><strong>振り返りが楽しくなる</strong>：「先月より増えてる！」と成長を実感</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- 5. ポイント・レベル -->
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>🎮 ポイントとレベル</h2>
+      <p>ハレを投稿するとポイントが貯まり、レベルアップしていきます。</p>
+      <ul>
+        <li><strong>投稿1回で+1ポイント</strong></li>
+        <li><strong>1日最大3ポイント</strong>：朝・昼・夜のハレを記録できます</li>
+        <li><strong>10ポイントでレベル1アップ</strong>：コツコツ続けることで成長を実感</li>
+      </ul>
+      <p class="text-sm text-gray-600">
+        ※ ポイントに特典はありません。自分の成長を楽しむためのものです。
+      </p>
+    </div>
+  </div>
+
+  <!-- 6. 始め方 -->
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>🚀 始め方</h2>
+      <ol>
+        <li><strong>アカウント登録</strong>：メールアドレスとパスワードで簡単登録</li>
+        <li><strong>献立相談で今日のごはんを考える</strong>：気軽に試してみましょう</li>
+        <li><strong>ハレを見つけたら投稿</strong>：「ちょっと特別」を記録</li>
+        <li><strong>カレンダーで振り返る</strong>：1週間、1か月の記録を楽しむ</li>
+      </ol>
+      <% if user_signed_in? %>
+        <div class="text-center mt-4">
+          <%= link_to "献立相談を始める", new_meal_search_path, class: "btn btn-primary" %>
+        </div>
+      <% else %>
+        <div class="text-center mt-4">
+          <%= link_to "アカウント登録", new_user_registration_path, class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- 7. FAQ -->
+  <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card-body prose max-w-none">
+      <h2>💡 よくある質問</h2>
+
+      <h3>Q1. 「ハレ」って、どのくらい特別じゃないとダメ？</h3>
+      <p>
+        <strong>A.</strong> 基準は自由です！「いつもよりちょっと良い」「ちょっと手間をかけた」「気分が上がった」など、あなたが「特別」と感じたらそれがハレです。
+      </p>
+
+      <h3>Q2. ポイントは何に使えるの？</h3>
+      <p>
+        <strong>A.</strong> ポイントは特典と交換できるものではありません。自分の成長や継続を楽しむための指標です。レベルが上がると達成感が得られます。
+      </p>
+
+      <h3>Q3. レシピは載っていないの？</h3>
+      <p>
+        <strong>A.</strong> ケハレ帖はレシピデータベースを持っていません。献立相談で候補を提案し、Google検索に誘導する形でレシピや食材を探せます。
+      </p>
+    </div>
+  </div>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,6 +2,8 @@
   text-base-content mt-8">
     <div>
       <p>
+        <%= link_to "使い方", how_to_use_path, class: "link link-hover" %>
+        |
         <%= link_to "プライバシーポリシー", privacy_policy_path, class: "link link-hover" %>
         |
         <%= link_to "利用規約", terms_path, class: "link link-hover" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "how_to_use", to: "pages#how_to_use"
   get "privacy_policy", to: "pages#privacy_policy"
   get "terms", to: "pages#terms"
   devise_for :users

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -125,4 +125,79 @@ RSpec.describe "Pages", type: :request do
       end
     end
   end
+
+  describe "GET /how_to_use" do
+    context '未ログイン時' do
+      it '正常にアクセスできる' do
+        get how_to_use_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it '使い方ページが表示される' do
+        get how_to_use_path
+        expect(response.body).to include('ケハレ帖の使い方')
+      end
+
+      it 'イントロセクションが表示される' do
+        get how_to_use_path
+        expect(response.body).to include('今日のごはんに、小さなハレを。')
+      end
+
+      it '献立相談機能の説明が表示される' do
+        get how_to_use_path
+        expect(response.body).to include('献立相談機能')
+      end
+
+      it 'ハレ投稿機能の説明が表示される' do
+        get how_to_use_path
+        expect(response.body).to include('ハレ投稿機能')
+      end
+
+      it 'カレンダー機能の説明が表示される' do
+        get how_to_use_path
+        expect(response.body).to include('カレンダー機能')
+      end
+
+      it 'ポイントとレベルの説明が表示される' do
+        get how_to_use_path
+        expect(response.body).to include('ポイントとレベル')
+      end
+
+      it '始め方セクションが表示される' do
+        get how_to_use_path
+        expect(response.body).to include('始め方')
+      end
+
+      it 'FAQセクションが表示される' do
+        get how_to_use_path
+        expect(response.body).to include('よくある質問')
+      end
+
+      it '未ログイン時はアカウント登録ボタンが表示される' do
+        get how_to_use_path
+        expect(response.body).to include('アカウント登録')
+      end
+    end
+
+    context 'ログイン時' do
+      let(:user) { User.create!(email: 'test@example.com', password: 'password') }
+
+      before { sign_in user }
+
+      it '正常にアクセスできる' do
+        get how_to_use_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it '使い方ページが表示される' do
+        get how_to_use_path
+        expect(response.body).to include('ケハレ帖の使い方')
+      end
+
+      it 'ログイン時は献立相談を始めるボタンが表示される' do
+        get how_to_use_path
+        expect(response.body).to include('献立相談を始める')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
初めてのユーザーがケハレ帖の使い方を理解できる専用ページを作成しました。アプリの世界観（ケ＝日常、ハレ＝小さな特別）と主要機能を分かりやすく伝えることを目的としています。

## 関連 Issue
closes #115

## 変更ファイル一覧

| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `config/routes.rb` | 修正 | `/how_to_use` ルーティングを追加 |
| `app/controllers/pages_controller.rb` | 修正 | `how_to_use` 空アクション追加 |
| `app/views/pages/how_to_use.html.erb` | **新規** | 使い方ページのビューテンプレート（7セクション構成） |
| `app/views/shared/_footer.html.erb` | 修正 | 「使い方」リンクを先頭に追加 |
| `spec/requests/pages_spec.rb` | 修正 | `GET /how_to_use` のリクエストスペック追加 |

## 実装のポイント

### ページ構成（7セクション）
1. **イントロ**: キャッチコピー「今日のごはんに、小さなハレを。」+ ケ/ハレの概念説明
2. **献立相談**: ジャンル選択 → 候補3つ → Google検索へ の流れを説明
3. **ハレ投稿**: 日付選択 → タグ選択 → ひとこと → 投稿 の流れを説明
4. **カレンダー**: スタンプで振り返り、1か月の記録が一目で分かることを説明
5. **ポイントとレベル**: +1pt/投稿、1日最大3pt、10ptでLv.1上昇を説明
6. **始め方**: 登録 → 献立相談 → ハレ投稿 → 振り返り（CTA付き）
7. **FAQ**: よくある質問3つに回答

### デザイン方針
- 既存の静的ページ（`privacy_policy.html.erb`, `terms.html.erb`）のパターンを踏襲
- daisyUI の `card` コンポーネントで統一感を確保
- 温かみのある表現で世界観を伝える
- ログイン状態に応じて CTA ボタンを切り替え（未ログイン: アカウント登録、ログイン: 献立相談）

### フッターリンクの配置
「使い方」リンクを**先頭**に配置し、初めてのユーザーが見つけやすくしました。

## テスト
- ✅ リクエストスペック: 未ログイン・ログイン両方で全セクションの表示を検証（34 examples, 0 failures）
- ✅ RuboCop: 全ファイルでエラーなし

## 動作確認方法

```bash
# ローカルで確認
docker compose up
# ブラウザで以下にアクセス
# - http://localhost:3000/how_to_use（未ログイン）
# - ログイン後、http://localhost:3000/how_to_use（ログイン状態）
```

## 残件・TODO
- なし（二重レンダリング問題は別 Issue で対応予定）