### PR TITLE
[Fix] 静的ページのヘッダー・フッター二重表示を修正

### DIFF
--- a/app/views/pages/how_to_use.html.erb
+++ b/app/views/pages/how_to_use.html.erb
@@ -1,5 +1,3 @@
-<%= render "shared/header" %>
-
 <div class="container mx-auto p-4 max-w-4xl">
   <h1 class="text-3xl font-bold mb-6 text-center">ケハレ帖の使い方</h1>
 
@@ -124,5 +122,3 @@
     </div>
   </div>
 </div>
-
-<%= render "shared/footer" %>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,5 +1,3 @@
-<%= render "shared/header" %>
-
 <div class="container mx-auto p-4 max-w-4xl">
   <h1 class="text-3xl font-bold mb-6">プライバシーポリシー</h1>
 
@@ -77,5 +75,3 @@
     </div>
   </div>
 </div>
-
-<%= render "shared/footer" %>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,5 +1,3 @@
-<%= render "shared/header" %>
-
 <div class="container mx-auto p-4 max-w-4xl">
   <h1 class="text-3xl font-bold mb-6">利用規約</h1>
 
@@ -89,5 +87,3 @@
     </div>
   </div>
 </div>
-
-<%= render "shared/footer" %>


### PR DESCRIPTION
## 概要
使い方・プライバシーポリシー・利用規約ページで発生していたヘッダー・フッターの二重表示問題を修正しました。

## 関連 Issue
closes #124

## 問題点
### ヘッダーの問題
- `application.html.erb` で `user_signed_in?` の場合のみヘッダーを表示する条件分岐がある
- しかし、各ページビュー（how_to_use, privacy_policy, terms）で `<%= render "shared/header" %>` を直接レンダリングしている
- 結果、未ログイン状態でもログイン向けのヘッダー（ホーム、カレンダー、献立相談、ハレ投稿、プロフィール、ログアウト）が表示される

### フッターの問題
- `application.html.erb` で `<%= render 'shared/footer' %>` をレンダリング
- 各ページビューでも `<%= render "shared/footer" %>` をレンダリング
- 結果、フッターが二重に表示される

## 修正内容

### 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/views/pages/how_to_use.html.erb` | 修正 | ヘッダー・フッターのレンダリングを削除 |
| `app/views/pages/privacy_policy.html.erb` | 修正 | ヘッダー・フッターのレンダリングを削除 |
| `app/views/pages/terms.html.erb` | 修正 | ヘッダー・フッターのレンダリングを削除 |

### 実装のポイント
- レイアウトファイル（`application.html.erb`）がヘッダー・フッターを管理するため、各ページビューでの重複レンダリングを削除
- `application.html.erb` の条件分岐（`user_signed_in?`）により、ログイン状態に応じたヘッダー表示を実現

## 修正後の動作
- **未ログイン状態:** ヘッダーなし、フッターのみ表示
- **ログイン状態:** ヘッダーあり、フッターあり

## テスト計画
- [x] how_to_use ページで未ログイン状態でヘッダーが表示されないこと
- [x] privacy_policy ページで未ログイン状態でヘッダーが表示されないこと
- [x] terms ページで未ログイン状態でヘッダーが表示されないこと
- [x] 各ページでフッターが1つだけ表示されること
- [x] ログイン状態では各ページでヘッダーが正常に表示されること

## 残件・TODO
なし