### PR TITLE
[Feature] MealCandidate seed データ増量（各ジャンル 20件）

### DIFF
--- a/db/seeds/meal_candidates.rb
+++ b/db/seeds/meal_candidates.rb
@@ -10,7 +10,22 @@ module Seeds
         { name: '親子丼', position: 2 },
         { name: '焼き魚', position: 3 },
         { name: '肉じゃが', position: 4 },
-        { name: '冷奴', position: 5 }
+        { name: '冷奴', position: 5 },
+        { name: '天ぷら', position: 6 },
+        { name: '筑前煮', position: 7 },
+        { name: '茶碗蒸し', position: 8 },
+        { name: '照り焼きチキン', position: 9 },
+        { name: '豚の生姜焼き', position: 10 },
+        { name: 'さばの味噌煮', position: 11 },
+        { name: 'きんぴらごぼう', position: 12 },
+        { name: 'かぼちゃの煮物', position: 13 },
+        { name: 'だし巻き卵', position: 14 },
+        { name: '納豆ごはん', position: 15 },
+        { name: 'お茶漬け', position: 16 },
+        { name: 'おでん', position: 17 },
+        { name: 'ぶり大根', position: 18 },
+        { name: '煮魚', position: 19 },
+        { name: 'とんかつ', position: 20 }
       ].each do |attrs|
         MealCandidate.find_or_create_by!(genre: japanese, name: attrs[:name]) do |mc|
           mc.position = attrs[:position]
@@ -25,7 +40,22 @@ module Seeds
         { name: 'ハンバーグ', position: 2 },
         { name: 'グラタン', position: 3 },
         { name: 'ポトフ', position: 4 },
-        { name: 'カルボナーラ', position: 5 }
+        { name: 'カルボナーラ', position: 5 },
+        { name: 'ビーフシチュー', position: 6 },
+        { name: 'クリームシチュー', position: 7 },
+        { name: 'ピザトースト', position: 8 },
+        { name: 'ドリア', position: 9 },
+        { name: 'ミートソーススパゲティ', position: 10 },
+        { name: 'ナポリタン', position: 11 },
+        { name: 'ペペロンチーノ', position: 12 },
+        { name: 'フライドチキン', position: 13 },
+        { name: 'ローストビーフ', position: 14 },
+        { name: 'コロッケ', position: 15 },
+        { name: 'エビフライ', position: 16 },
+        { name: 'ポークソテー', position: 17 },
+        { name: 'チキンソテー', position: 18 },
+        { name: 'ラザニア', position: 19 },
+        { name: 'キッシュ', position: 20 }
       ].each do |attrs|
         MealCandidate.find_or_create_by!(genre: western, name: attrs[:name]) do |mc|
           mc.position = attrs[:position]
@@ -40,7 +70,22 @@ module Seeds
         { name: 'チャーハン', position: 2 },
         { name: '餃子', position: 3 },
         { name: '青椒肉絲', position: 4 },
-        { name: '酸辣湯', position: 5 }
+        { name: '酸辣湯', position: 5 },
+        { name: 'エビチリ', position: 6 },
+        { name: '回鍋肉', position: 7 },
+        { name: '八宝菜', position: 8 },
+        { name: '棒棒鶏', position: 9 },
+        { name: '春巻き', position: 10 },
+        { name: 'よだれ鶏', position: 11 },
+        { name: '中華丼', position: 12 },
+        { name: '天津飯', position: 13 },
+        { name: '担々麺', position: 14 },
+        { name: '小籠包', position: 15 },
+        { name: 'ワンタンスープ', position: 16 },
+        { name: 'ニラ玉', position: 17 },
+        { name: 'ホイコーロー', position: 18 },
+        { name: 'ユーリンチー', position: 19 },
+        { name: 'チンジャオロース', position: 20 }
       ].each do |attrs|
         MealCandidate.find_or_create_by!(genre: chinese, name: attrs[:name]) do |mc|
           mc.position = attrs[:position]
@@ -55,7 +100,22 @@ module Seeds
         { name: 'うどん', position: 2 },
         { name: 'そば', position: 3 },
         { name: 'パスタ', position: 4 },
-        { name: '焼きそば', position: 5 }
+        { name: '焼きそば', position: 5 },
+        { name: 'きつねうどん', position: 6 },
+        { name: 'たぬきそば', position: 7 },
+        { name: 'カレーうどん', position: 8 },
+        { name: '冷やし中華', position: 9 },
+        { name: 'つけ麺', position: 10 },
+        { name: 'そうめん', position: 11 },
+        { name: 'ざるそば', position: 12 },
+        { name: 'とんこつラーメン', position: 13 },
+        { name: '味噌ラーメン', position: 14 },
+        { name: '醤油ラーメン', position: 15 },
+        { name: 'フォー', position: 16 },
+        { name: 'ビーフン', position: 17 },
+        { name: 'パッタイ', position: 18 },
+        { name: 'まぜそば', position: 19 },
+        { name: 'あんかけ焼きそば', position: 20 }
       ].each do |attrs|
         MealCandidate.find_or_create_by!(genre: noodle, name: attrs[:name]) do |mc|
           mc.position = attrs[:position]
@@ -70,7 +130,22 @@ module Seeds
         { name: '天丼', position: 2 },
         { name: 'カツ丼', position: 3 },
         { name: '海鮮丼', position: 4 },
-        { name: '親子丼', position: 5 }
+        { name: '親子丼', position: 5 },
+        { name: '豚丼', position: 6 },
+        { name: 'ネギトロ丼', position: 7 },
+        { name: 'うな丼', position: 8 },
+        { name: 'そぼろ丼', position: 9 },
+        { name: 'ロコモコ丼', position: 10 },
+        { name: '中華丼', position: 11 },
+        { name: 'ビビンバ丼', position: 12 },
+        { name: 'アボカド丼', position: 13 },
+        { name: 'まぐろ丼', position: 14 },
+        { name: 'サーモン丼', position: 15 },
+        { name: '鉄火丼', position: 16 },
+        { name: 'ステーキ丼', position: 17 },
+        { name: '焼き鳥丼', position: 18 },
+        { name: 'エビ天丼', position: 19 },
+        { name: '照り焼きチキン丼', position: 20 }
       ].each do |attrs|
         MealCandidate.find_or_create_by!(genre: rice_bowl, name: attrs[:name]) do |mc|
           mc.position = attrs[:position]
@@ -85,7 +160,22 @@ module Seeds
         { name: 'コーンスープ', position: 2 },
         { name: '味噌汁', position: 3 },
         { name: '豚汁', position: 4 },
-        { name: 'クラムチャウダー', position: 5 }
+        { name: 'クラムチャウダー', position: 5 },
+        { name: 'オニオンスープ', position: 6 },
+        { name: 'トマトスープ', position: 7 },
+        { name: 'かぼちゃスープ', position: 8 },
+        { name: 'きのこスープ', position: 9 },
+        { name: '卵スープ', position: 10 },
+        { name: 'わかめスープ', position: 11 },
+        { name: 'コンソメスープ', position: 12 },
+        { name: 'ボルシチ', position: 13 },
+        { name: 'ガスパチョ', position: 14 },
+        { name: 'けんちん汁', position: 15 },
+        { name: 'お吸い物', position: 16 },
+        { name: 'あさりの味噌汁', position: 17 },
+        { name: 'じゃがいもスープ', position: 18 },
+        { name: 'レンズ豆スープ', position: 19 },
+        { name: '白菜スープ', position: 20 }
       ].each do |attrs|
         MealCandidate.find_or_create_by!(genre: soup, name: attrs[:name]) do |mc|
           mc.position = attrs[:position]
@@ -100,7 +190,22 @@ module Seeds
         { name: 'ポテトサラダ', position: 2 },
         { name: 'コールスロー', position: 3 },
         { name: 'グリーンサラダ', position: 4 },
-        { name: '春雨サラダ', position: 5 }
+        { name: '春雨サラダ', position: 5 },
+        { name: 'チョレギサラダ', position: 6 },
+        { name: 'カプレーゼ', position: 7 },
+        { name: 'ニース風サラダ', position: 8 },
+        { name: '大根サラダ', position: 9 },
+        { name: 'トマトサラダ', position: 10 },
+        { name: 'アボカドサラダ', position: 11 },
+        { name: 'ツナサラダ', position: 12 },
+        { name: '豆腐サラダ', position: 13 },
+        { name: 'マカロニサラダ', position: 14 },
+        { name: 'コブサラダ', position: 15 },
+        { name: 'ごぼうサラダ', position: 16 },
+        { name: 'キャベツサラダ', position: 17 },
+        { name: '水菜サラダ', position: 18 },
+        { name: 'きゅうりサラダ', position: 19 },
+        { name: 'かぼちゃサラダ', position: 20 }
       ].each do |attrs|
         MealCandidate.find_or_create_by!(genre: salad, name: attrs[:name]) do |mc|
           mc.position = attrs[:position]
@@ -115,7 +220,22 @@ module Seeds
         { name: '冷奴', position: 2 },
         { name: '唐揚げ', position: 3 },
         { name: 'ポテトフライ', position: 4 },
-        { name: 'チーズ盛り合わせ', position: 5 }
+        { name: 'チーズ盛り合わせ', position: 5 },
+        { name: '揚げ出し豆腐', position: 6 },
+        { name: 'ナッツ', position: 7 },
+        { name: 'ピクルス', position: 8 },
+        { name: 'メンマ', position: 9 },
+        { name: '漬物', position: 10 },
+        { name: 'たこわさ', position: 11 },
+        { name: 'いかの塩辛', position: 12 },
+        { name: 'アヒージョ', position: 13 },
+        { name: 'カマンベールチーズフライ', position: 14 },
+        { name: '焼き鳥', position: 15 },
+        { name: '刺身盛り合わせ', position: 16 },
+        { name: 'カルパッチョ', position: 17 },
+        { name: '生ハムメロン', position: 18 },
+        { name: 'バーニャカウダ', position: 19 },
+        { name: 'エイヒレ', position: 20 }
       ].each do |attrs|
         MealCandidate.find_or_create_by!(genre: snack, name: attrs[:name]) do |mc|
           mc.position = attrs[:position]

--- a/spec/models/seeds/meal_candidates_seed_spec.rb
+++ b/spec/models/seeds/meal_candidates_seed_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe Seeds::MealCandidates do
         expect { described_class.call }.to change(MealCandidate, :count).by_at_least(1)
       end
 
-      it '各ジャンルに最低3件の候補が存在すること' do
+      it '各ジャンルに最低20件の候補が存在すること' do
         described_class.call
         Genre.all.each do |genre|
-          expect(genre.meal_candidates.count).to be >= 3
+          expect(genre.meal_candidates.count).to be >= 20
         end
       end
 


### PR DESCRIPTION
## 概要
MealCandidate の候補を各ジャンル 5件 → 20件に増量し、献立提案のバリエーションを向上させました。

## 関連 Issue
closes #102

## 変更内容
- **seed データ増量:** 各ジャンル 20件（合計 160件）に増加
- **料理選定:** 一人暮らしの料理初心者向けの現実的で馴染みのある料理名を選定
- **冪等性維持:** 既存の `find_or_create_by!` パターンを維持
- **テスト更新:** 最低件数チェックを `>= 3` → `>= 20` に変更

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `db/seeds/meal_candidates.rb` | 修正 | 各ジャンルの候補を 20件に増量 |
| `spec/models/seeds/meal_candidates_seed_spec.rb` | 修正 | 最低件数チェックを 20件に変更 |

## 実装のポイント
- **既存の 5件を維持:** position 1〜5 はそのまま残し、position 6〜20 を追加
- **ジャンル別の特徴を考慮:**
  - 和食: 天ぷら、筑前煮、豚の生姜焼きなど
  - 洋食: ビーフシチュー、ドリア、ペペロンチーノなど
  - 中華: エビチリ、回鍋肉、よだれ鶏など
  - 麺: きつねうどん、冷やし中華、フォーなど
  - 丼: 豚丼、ロコモコ丼、ビビンバ丼など
  - スープ: オニオンスープ、ボルシチ、けんちん汁など
  - サラダ: チョレギサラダ、カプレーゼ、コブサラダなど
  - おつまみ: アヒージョ、焼き鳥、カルパッチョなど

## テスト結果
```
✅ seed テスト: 6 examples, 0 failures
✅ 全テスト: 507 examples, 0 failures
✅ カバレッジ: 96.93%
✅ RuboCop: no offenses detected
```

## 残件・TODO
- なし（所要時間の紐づけは別 Issue として実装予定）