### PR TITLE
[UI改善] 公開タイムラインの視認性向上

### DIFF
--- a/app/views/hare_entries/public.html.erb
+++ b/app/views/hare_entries/public.html.erb
@@ -10,13 +10,13 @@
     <% if @hare_entries.any? %>
       <div class="space-y-4">
         <% @hare_entries.each do |entry| %>
-          <div class="card bg-base-100 shadow-xl">
+          <div class="card bg-white shadow-md">
             <div class="card-body">
               <!-- ユーザー情報 -->
               <div class="flex items-center mb-3">
-                <div class="avatar placeholder">
-                  <div class="bg-neutral text-neutral-content rounded-full w-10">
-                    <span class="text-sm"><%= entry.user.display_name.first.upcase %></span>
+                <div class="avatar">
+                  <div class="w-10 rounded-full">
+                    <%= image_tag level_image_url(entry.user.level), alt: entry.user.display_name, class: "rounded-full" %>
                   </div>
                 </div>
                 <div class="ml-3">
@@ -39,7 +39,7 @@
               <% if entry.hare_tags.any? %>
                 <div class="flex flex-wrap gap-2">
                   <% entry.hare_tags.each do |tag| %>
-                    <span class="badge badge-primary badge-outline">
+                    <span class="badge badge-accent">
                       <%= tag.label %>
                     </span>
                   <% end %>


### PR DESCRIPTION
## 概要
公開タイムラインのUIを改善し、視認性と世界観に合った温かみのあるデザインに変更しました。

## 関連 Issue
closes #143

## 変更内容

### 1. カード背景の改善
- `bg-base-100` → `bg-white`
- ダークモード時に黒くならず、常に白背景で読みやすく

### 2. シャドウの調整
- `shadow-xl` → `shadow-md`
- 柔らかい印象に変更

### 3. タグの色変更
- `badge-primary badge-outline` → `badge-accent`
- 青系から温かみのあるアクセントカラーに変更

### 4. アイコンのレベルイラスト化
- イニシャル文字 → `level_image_url(entry.user.level)`
- レベルシステムの視覚的訴求力向上

## 変更ファイル一覧

| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/views/hare_entries/public.html.erb` | 修正 | UI改善（背景・シャドウ・タグ・アイコン） |

## スクリーンショット

**Before:** 黒背景で見にくい、イニシャルアイコン  
**After:** 白背景で読みやすい、レベルイラストアイコン

## テスト計画
- [x] 公開タイムラインにアクセスして視覚的に確認
- [x] カード背景が白になっているか確認
- [x] タグの色が温かみのある色になっているか確認
- [x] アイコンがレベルイラストになっているか確認

## 残件・TODO
- なし