### PR TITLE
[UI] モバイルレスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -22,7 +22,7 @@
   }
 
   table {
-    @apply w-full mx-auto;
+    @apply w-full mx-auto min-w-[500px];
   }
 
   table thead th {

--- a/app/views/calendar/index.html.erb
+++ b/app/views/calendar/index.html.erb
@@ -1,9 +1,9 @@
-<main class="max-w-7xl mx-auto p-8">
+<main class="max-w-7xl mx-auto p-4 md:p-8">
   <%# ページヘッダー %>
   <div class="mb-8">
     <div class="flex items-center gap-3 mb-2">
       <span class="text-4xl">📅</span>
-      <h1 class="text-3xl font-bold text-gray-800">ハレのカレンダー</h1>
+      <h1 class="text-2xl md:text-3xl font-bold text-gray-800">ハレのカレンダー</h1>
     </div>
     <p class="text-gray-600">あなたのハレを振り返りましょう</p>
   </div>
@@ -11,7 +11,7 @@
   <%# カレンダー本体 %>
   <div class="bg-white rounded-2xl shadow-sm p-6 overflow-x-auto">
     <%= month_calendar(events: @hare_entries, attribute: :occurred_on) do |date, entries| %>
-      <div class="h-[120px] p-3 hover:bg-orange-50 rounded-lg transition-colors overflow-hidden">
+      <div class="h-[80px] md:h-[120px] p-1 md:p-3 hover:bg-orange-50 rounded-lg transition-colors overflow-hidden">
         <%= link_to date.day, calendar_date_path(date: date), class: "font-bold text-lg text-gray-700 hover:text-orange-600 transition-colors" %>
         <div class="mt-2 space-y-1">
           <% entries.first(2).each do |entry| %>

--- a/app/views/calendar/show.html.erb
+++ b/app/views/calendar/show.html.erb
@@ -1,9 +1,9 @@
-<main class="max-w-4xl mx-auto p-8">
+<main class="max-w-4xl mx-auto p-4 md:p-8">
   <%# ページヘッダー %>
   <div class="mb-8">
-    <div class="flex items-center gap-3 mb-4">
-      <span class="text-4xl">📅</span>
-      <h1 class="text-3xl font-bold text-gray-800">
+    <div class="flex items-center gap-2 md:gap-3 mb-4">
+      <span class="text-2xl md:text-4xl">📅</span>
+      <h1 class="text-xl md:text-3xl font-bold text-gray-800">
         <%= @date.strftime("%Y年%-m月%-d日") %> のハレ投稿
       </h1>
     </div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,29 @@
-<h2><%= t('.resend_confirmation_instructions') %></h2>
+<% content_for :hide_header, true %>
+<% content_for :hide_footer, true %>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="min-h-screen bg-gray-100 flex items-center justify-center py-12 px-4">
+  <div class="card bg-white shadow-xl w-full max-w-md">
+    <div class="card-body">
+      <h2 class="card-title text-2xl text-gray-900 mb-6"><%= t('.resend_confirmation_instructions') %></h2>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+      <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+
+        <div class="form-control mb-4">
+          <%= f.label :email, class: "label text-gray-700 font-semibold" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+              value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
+              class: "input input-bordered w-full bg-white text-gray-900 border-gray-300 focus:border-orange-500 focus:ring-2 focus:ring-orange-200" %>
+        </div>
+
+        <div class="form-control mt-6">
+          <%= f.submit t('.resend_confirmation_instructions'), class: "btn bg-orange-600 hover:bg-orange-700 text-white w-full border-0" %>
+        </div>
+      <% end %>
+
+      <div class="mt-6">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit t('.resend_confirmation_instructions') %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,16 +1,28 @@
-<h2><%= t('.resend_unlock_instructions') %></h2>
+<% content_for :hide_header, true %>
+<% content_for :hide_footer, true %>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="min-h-screen bg-gray-100 flex items-center justify-center py-12 px-4">
+  <div class="card bg-white shadow-xl w-full max-w-md">
+    <div class="card-body">
+      <h2 class="card-title text-2xl text-gray-900 mb-6"><%= t('.resend_unlock_instructions') %></h2>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+
+        <div class="form-control mb-4">
+          <%= f.label :email, class: "label text-gray-700 font-semibold" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+              class: "input input-bordered w-full bg-white text-gray-900 border-gray-300 focus:border-orange-500 focus:ring-2 focus:ring-orange-200" %>
+        </div>
+
+        <div class="form-control mt-6">
+          <%= f.submit t('.resend_unlock_instructions'), class: "btn bg-orange-600 hover:bg-orange-700 text-white w-full border-0" %>
+        </div>
+      <% end %>
+
+      <div class="mt-6">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit t('.resend_unlock_instructions') %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/hare_entries/_form.html.erb
+++ b/app/views/hare_entries/_form.html.erb
@@ -52,14 +52,14 @@
 
     <%# プレビューエリア %>
     <div data-image-preview-target="previewContainer" class="mt-4 hidden">
-      <img data-image-preview-target="preview" class="max-w-md rounded-xl border-2 border-gray-300 shadow-sm">
+      <img data-image-preview-target="preview" class="max-w-full md:max-w-md rounded-xl border-2 border-gray-300 shadow-sm">
     </div>
 
     <%# 既存の写真表示と削除チェックボックス %>
     <% if hare_entry.photo.attached? %>
       <div class="mt-4">
         <p class="text-sm font-bold text-gray-800 mb-2">現在の写真</p>
-        <%= image_tag hare_entry.photo.variant(resize_to_limit: [200, 200]), class: "max-w-md rounded-xl border-2 border-gray-300 shadow-sm" %>
+        <%= image_tag hare_entry.photo.variant(resize_to_limit: [200, 200]), class: "max-w-full md:max-w-md rounded-xl border-2 border-gray-300 shadow-sm" %>
         <label class="flex items-center gap-2 mt-3">
           <%= f.check_box :remove_photo, class: "rounded text-red-500 focus:ring-red-400" %>
           <span class="text-sm font-medium text-gray-800">写真を削除する</span>
@@ -69,8 +69,8 @@
   </div>
 
   <%# ボタン %>
-  <div class="flex gap-4 pt-4">
-    <%= f.submit submit_label, class: "bg-gradient-to-r from-orange-400 to-orange-300 text-white px-8 py-3 rounded-full font-semibold hover:from-orange-500 hover:to-orange-400 transition-colors shadow-md" %>
-    <%= link_to "キャンセル", cancel_path, class: "px-8 py-3 text-gray-600 hover:text-gray-800 font-semibold" %>
+  <div class="flex flex-col sm:flex-row gap-3 sm:gap-4 pt-4">
+    <%= f.submit submit_label, class: "bg-gradient-to-r from-orange-400 to-orange-300 text-white px-6 md:px-8 py-3 rounded-full font-semibold hover:from-orange-500 hover:to-orange-400 transition-colors shadow-md w-full sm:w-auto" %>
+    <%= link_to "キャンセル", cancel_path, class: "px-6 md:px-8 py-3 text-gray-600 hover:text-gray-800 font-semibold text-center" %>
   </div>
 <% end %>

--- a/app/views/hare_entries/edit.html.erb
+++ b/app/views/hare_entries/edit.html.erb
@@ -1,4 +1,4 @@
-<main class="max-w-3xl mx-auto p-8">
+<main class="max-w-3xl mx-auto p-4 md:p-8">
   <%# 戻るリンク %>
   <div class="mb-4">
     <%= link_to "← 詳細に戻る", hare_entry_path(@hare_entry), class: "text-gray-600 hover:text-gray-800 font-medium" %>
@@ -11,7 +11,7 @@
   </div>
 
   <%# フォームカード %>
-  <div class="bg-white rounded-2xl shadow-sm p-8">
+  <div class="bg-white rounded-2xl shadow-sm p-5 md:p-8">
     <%= render 'form', hare_entry: @hare_entry, submit_label: "更新する", cancel_path: hare_entry_path(@hare_entry), hare_tags: @hare_tags %>
   </div>
 </main>

--- a/app/views/hare_entries/index.html.erb
+++ b/app/views/hare_entries/index.html.erb
@@ -1,25 +1,25 @@
-<main class="max-w-5xl mx-auto p-8">
+<main class="max-w-5xl mx-auto p-4 md:p-8">
   <%# ページタイトル %>
-  <h1 class="text-3xl font-bold text-gray-800 mb-6">あなたのハレ一覧</h1>
+  <h1 class="text-2xl md:text-3xl font-bold text-gray-800 mb-6">あなたのハレ一覧</h1>
 
   <%# 今月のポイントとレベル表示（Stitch 風カード） %>
   <div class="bg-white rounded-2xl shadow-sm p-6 mb-8">
-    <div class="flex items-center justify-between">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
       <div>
         <p class="text-xs text-orange-600 font-semibold uppercase tracking-wider mb-2">● MONTHLY PROGRESS</p>
-        <div class="flex items-center gap-8">
+        <div class="flex items-center gap-4 md:gap-8">
           <div>
             <p class="text-sm text-gray-500 mb-1">今月のがんばり</p>
-            <p class="text-3xl font-bold text-orange-500"><%= @monthly_points || 0 %><span class="text-lg text-gray-600">pt</span></p>
+            <p class="text-2xl md:text-3xl font-bold text-orange-500"><%= @monthly_points || 0 %><span class="text-lg text-gray-600">pt</span></p>
           </div>
           <div class="h-12 w-px bg-gray-200"></div>
           <div>
             <p class="text-sm text-gray-500 mb-1">ハレ度</p>
-            <p class="text-3xl font-bold text-gray-800">Lv.<%= @level || 0 %></p>
+            <p class="text-2xl md:text-3xl font-bold text-gray-800">Lv.<%= @level || 0 %></p>
           </div>
         </div>
       </div>
-      <div class="text-5xl">🌸</div>
+      <div class="text-3xl md:text-5xl mt-3 sm:mt-0">🌸</div>
     </div>
   </div>
 

--- a/app/views/hare_entries/new.html.erb
+++ b/app/views/hare_entries/new.html.erb
@@ -1,4 +1,4 @@
-<main class="max-w-3xl mx-auto p-8">
+<main class="max-w-3xl mx-auto p-4 md:p-8">
   <%# ページヘッダー %>
   <div class="mb-6">
     <h1 class="text-3xl font-bold text-gray-800 mb-2">今日のハレを記録する</h1>
@@ -6,7 +6,7 @@
   </div>
 
   <%# フォームカード %>
-  <div class="bg-white rounded-2xl shadow-sm p-8">
+  <div class="bg-white rounded-2xl shadow-sm p-5 md:p-8">
     <%= render 'form', hare_entry: @hare_entry, hare_tags: @hare_tags, submit_label: "記録する", cancel_path: root_path %>
   </div>
 </main>

--- a/app/views/hare_entries/public.html.erb
+++ b/app/views/hare_entries/public.html.erb
@@ -2,7 +2,7 @@
   <div class="max-w-3xl mx-auto">
     <!-- ヘッダー -->
     <div class="mb-6">
-      <h1 class="text-3xl font-bold text-gray-800 mb-2">みんなのハレ</h1>
+      <h1 class="text-2xl md:text-3xl font-bold text-gray-800 mb-2">みんなのハレ</h1>
       <p class="text-gray-600">他のユーザーのハレ投稿を見てみましょう</p>
     </div>
 
@@ -26,12 +26,12 @@
               </div>
 
               <!-- 投稿内容 -->
-              <p class="text-gray-700 mb-3"><%= entry.body %></p>
+              <p class="text-gray-700 mb-3 break-words"><%= entry.body %></p>
 
               <!-- 写真 -->
               <% if entry.photo.attached? %>
                 <div class="mb-3">
-                  <%= image_tag entry.photo, class: "rounded-lg max-h-96 w-auto mx-auto" %>
+                  <%= image_tag entry.photo, class: "rounded-lg max-h-96 max-w-full w-auto mx-auto" %>
                 </div>
               <% end %>
 

--- a/app/views/hare_entries/show.html.erb
+++ b/app/views/hare_entries/show.html.erb
@@ -1,13 +1,13 @@
-<main class="max-w-3xl mx-auto p-8">
+<main class="max-w-3xl mx-auto p-4 md:p-8">
   <%# 戻るリンク %>
   <div class="mb-6">
     <%= link_to "← 一覧に戻る", hare_entries_path, class: "text-gray-600 hover:text-gray-800 font-medium" %>
   </div>
 
   <%# メインカード %>
-  <div class="bg-white rounded-2xl shadow-sm p-8">
+  <div class="bg-white rounded-2xl shadow-sm p-5 md:p-8">
     <%# ヘッダー情報 %>
-    <div class="flex justify-between items-center mb-6 pb-4 border-b border-gray-100">
+    <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 mb-6 pb-4 border-b border-gray-100">
       <div class="flex items-center gap-3">
         <span class="text-3xl">✨</span>
         <p class="text-lg font-medium text-gray-700">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,9 @@
 <% if user_signed_in? %>
     <%# ログイン後のホーム画面（Stitch完全コピー） %>
-    <main class="max-w-5xl mx-auto bg-[#FEF7ED] min-h-screen p-8">
+    <main class="max-w-5xl mx-auto bg-[#FEF7ED] min-h-screen p-4 md:p-8">
       <%# 挨拶エリア %>
       <div class="mb-6">
-        <h1 class="text-3xl font-bold text-gray-800 mb-1">こんにちは、<%= current_user.display_name %> さん</h1>
+        <h1 class="text-2xl md:text-3xl font-bold text-gray-800 mb-1">こんにちは、<%= current_user.display_name %> さん</h1>
         <p class="text-sm text-gray-500">今日も1日を大切に過ごしましょう</p>
       </div>
 
@@ -29,10 +29,10 @@
           </div>
 
           <%# レベルイラスト %>
-          <div class="flex-shrink-0 ml-6">
+          <div class="flex-shrink-0 ml-3 md:ml-6">
             <%= image_tag level_image_url(@level || 0),
                           alt: level_name(@level || 0),
-                          class: "w-32 h-32 rounded-full shadow-md object-cover" %>
+                          class: "w-20 h-20 md:w-32 md:h-32 rounded-full shadow-md object-cover" %>
           </div>
         </div>
       </div>
@@ -40,36 +40,36 @@
       <%# メインアクションカード（2つ横並び・Stitch完全再現） %>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
         <%# 献立相談カード（深緑） %>
-        <div class="bg-[#7A9D7E] rounded-3xl p-8 shadow-lg relative overflow-hidden min-h-[240px]">
+        <div class="bg-[#7A9D7E] rounded-3xl p-5 md:p-8 shadow-lg relative overflow-hidden min-h-[200px] md:min-h-[240px] flex flex-col">
           <%# 背景の丸（装飾）+ 絵文字 %>
           <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-32 h-32 bg-white/10 rounded-full flex items-center justify-center">
             <div class="text-5xl">🍚</div>
           </div>
 
-          <div class="relative z-10">
+          <div class="relative z-10 flex flex-col flex-1">
             <h2 class="text-white text-xl font-bold mb-1">今日のごはん、</h2>
-            <h2 class="text-white text-xl font-bold mb-8">どうする？</h2>
+            <h2 class="text-white text-xl font-bold mb-4 md:mb-8">どうする？</h2>
 
             <%# ボタン %>
-            <div class="absolute bottom-8 right-8">
+            <div class="mt-auto flex justify-end">
               <%= link_to "相談する", new_meal_search_path, class: "bg-white text-[#7A9D7E] px-6 py-2 rounded-full font-semibold text-sm hover:bg-gray-50 transition-colors shadow-md" %>
             </div>
           </div>
         </div>
 
         <%# ハレ記録カード（オレンジ） %>
-        <div class="bg-gradient-to-br from-[#D4845F] to-[#C97D5D] rounded-3xl p-8 shadow-lg relative overflow-hidden min-h-[240px]">
+        <div class="bg-gradient-to-br from-[#D4845F] to-[#C97D5D] rounded-3xl p-5 md:p-8 shadow-lg relative overflow-hidden min-h-[200px] md:min-h-[240px] flex flex-col">
           <%# 背景の丸（装飾）+ 絵文字 %>
           <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-32 h-32 bg-white/10 rounded-full flex items-center justify-center">
             <div class="text-5xl">✨</div>
           </div>
 
-          <div class="relative z-10">
+          <div class="relative z-10 flex flex-col flex-1">
             <h2 class="text-white text-xl font-bold mb-1">今日、いいこと</h2>
-            <h2 class="text-white text-xl font-bold mb-8">あった？</h2>
+            <h2 class="text-white text-xl font-bold mb-4 md:mb-8">あった？</h2>
 
             <%# ボタン %>
-            <div class="absolute bottom-8 right-8">
+            <div class="mt-auto flex justify-end">
               <%= link_to "記録する", new_hare_entry_path, class: "bg-white text-[#D4845F] px-6 py-2 rounded-full font-semibold text-sm hover:bg-gray-50 transition-colors shadow-md" %>
             </div>
           </div>

--- a/app/views/meal_searches/index.html.erb
+++ b/app/views/meal_searches/index.html.erb
@@ -1,7 +1,7 @@
-<main class="max-w-5xl mx-auto p-8">
+<main class="max-w-5xl mx-auto p-4 md:p-8">
   <%# ページヘッダー %>
-  <div class="flex items-center justify-between mb-8">
-    <h1 class="text-3xl font-bold text-gray-800">献立相談のログ</h1>
+  <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-8">
+    <h1 class="text-2xl md:text-3xl font-bold text-gray-800">献立相談のログ</h1>
     <div class="flex gap-3">
       <%= link_to "新しく相談する", new_meal_search_path, class: "bg-gradient-to-r from-green-500 to-green-400 text-white px-6 py-2.5 rounded-full font-semibold hover:from-green-600 hover:to-green-500 transition-colors shadow-sm" %>
       <%= link_to "ホーム", home_path, class: "text-gray-600 hover:text-gray-800 font-medium" %>
@@ -48,7 +48,7 @@
             </div>
             <div class="text-gray-700">
               <span class="font-semibold">提案された候補:</span>
-              <span class="text-gray-600"><%= meal_search.presented_candidate_names.join(", ") %></span>
+              <span class="text-gray-600 break-words"><%= meal_search.presented_candidate_names.join(", ") %></span>
             </div>
           </div>
         <% end %>

--- a/app/views/meal_searches/new.html.erb
+++ b/app/views/meal_searches/new.html.erb
@@ -1,4 +1,4 @@
-<main class="max-w-3xl mx-auto p-8">
+<main class="max-w-3xl mx-auto p-4 md:p-8">
   <%# ページヘッダー %>
   <div class="flex items-center justify-between mb-6">
     <div>
@@ -9,23 +9,23 @@
   </div>
 
   <%# フォームカード %>
-  <div class="bg-white rounded-2xl shadow-sm p-8">
+  <div class="bg-white rounded-2xl shadow-sm p-5 md:p-8">
     <%= form_with url: meal_searches_path, method: :post, local: true, class: "space-y-8", data: { controller: "meal-search-form", turbo: false } do |f| %>
 
       <%# 自炊 or 外食 %>
       <div>
         <label class="block text-sm font-semibold text-gray-700 mb-3">今日はどうする？</label>
-        <div class="flex gap-4">
+        <div class="flex flex-col sm:flex-row gap-3 sm:gap-4">
           <label class="flex-1 relative cursor-pointer">
             <%= f.radio_button :cook_context, "self_cook", class: "peer sr-only", data: { action: "change->meal-search-form#toggleMinutes" } %>
-            <div class="flex items-center justify-center gap-2 px-6 py-4 bg-gray-50 peer-checked:bg-green-50 border-2 border-gray-200 peer-checked:border-green-400 rounded-xl transition-all">
+            <div class="flex items-center justify-center gap-2 px-4 py-3 sm:px-6 sm:py-4 bg-gray-50 peer-checked:bg-green-50 border-2 border-gray-200 peer-checked:border-green-400 rounded-xl transition-all">
               <span class="text-2xl">🍳</span>
               <span class="font-semibold text-gray-700 peer-checked:text-green-700">自炊する</span>
             </div>
           </label>
           <label class="flex-1 relative cursor-pointer">
             <%= f.radio_button :cook_context, "eat_out", class: "peer sr-only", data: { action: "change->meal-search-form#toggleMinutes" } %>
-            <div class="flex items-center justify-center gap-2 px-6 py-4 bg-gray-50 peer-checked:bg-orange-50 border-2 border-gray-200 peer-checked:border-orange-400 rounded-xl transition-all">
+            <div class="flex items-center justify-center gap-2 px-4 py-3 sm:px-6 sm:py-4 bg-gray-50 peer-checked:bg-orange-50 border-2 border-gray-200 peer-checked:border-orange-400 rounded-xl transition-all">
               <span class="text-2xl">🍽️</span>
               <span class="font-semibold text-gray-700 peer-checked:text-orange-700">外で食べる</span>
             </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,28 +1,28 @@
-<main class="max-w-4xl mx-auto p-8">
+<main class="max-w-4xl mx-auto p-4 md:p-8">
   <%# ページヘッダー %>
   <div class="mb-8">
     <div class="flex items-center gap-3 mb-2">
       <span class="text-4xl">👤</span>
-      <h1 class="text-3xl font-bold text-gray-800">プロフィール</h1>
+      <h1 class="text-2xl md:text-3xl font-bold text-gray-800">プロフィール</h1>
     </div>
     <p class="text-gray-600">あなたの情報と記録</p>
   </div>
 
   <%# プロフィールカード %>
-  <div class="bg-white rounded-2xl shadow-sm p-8">
+  <div class="bg-white rounded-2xl shadow-sm p-5 md:p-8">
     <h2 class="text-xl font-bold text-gray-800 mb-6">基本情報</h2>
 
     <div class="space-y-6">
       <%# 表示名 %>
-      <div class="flex items-center justify-between py-4 border-b border-gray-100">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 py-4 border-b border-gray-100">
         <span class="text-sm font-semibold text-gray-600">表示名</span>
         <span class="text-lg font-medium text-gray-800"><%= @user.display_name %></span>
       </div>
 
       <%# メールアドレス %>
-      <div class="flex items-center justify-between py-4 border-b border-gray-100">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 py-4 border-b border-gray-100">
         <span class="text-sm font-semibold text-gray-600">メールアドレス</span>
-        <span class="text-lg text-gray-800"><%= @user.email %></span>
+        <span class="text-lg text-gray-800 break-all"><%= @user.email %></span>
       </div>
 
       <%# 現在のレベル %>
@@ -38,7 +38,7 @@
         <div class="flex justify-center mt-4">
           <%= image_tag level_image_url(@user.level),
                         alt: level_name(@user.level),
-                        class: "w-40 h-40 rounded-full shadow-lg object-cover" %>
+                        class: "w-28 h-28 md:w-40 md:h-40 rounded-full shadow-lg object-cover" %>
         </div>
       </div>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,13 +1,12 @@
 <footer class="footer footer-center p-4 bg-orange-50 text-gray-700 mt-8">
-    <div>
-      <p>
-        <%= link_to "使い方", how_to_use_path, class: "text-gray-700 hover:text-orange-600 transition-colors" %>
-        <span class="text-gray-400">|</span>
-        <%= link_to "プライバシーポリシー", privacy_policy_path, class: "text-gray-700 hover:text-orange-600 transition-colors" %>
-        <span class="text-gray-400">|</span>
-        <%= link_to "利用規約", terms_path, class: "text-gray-700 hover:text-orange-600 transition-colors" %>
-      </p>
-      <p class="text-gray-600">&copy; 2026 <%= t('app_name') %></p>
+  <div>
+    <div class="flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
+      <%= link_to "使い方", how_to_use_path, class: "text-gray-700 hover:text-orange-600 transition-colors" %>
+      <span class="text-gray-400">|</span>
+      <%= link_to "プライバシーポリシー", privacy_policy_path, class: "text-gray-700 hover:text-orange-600 transition-colors" %>
+      <span class="text-gray-400">|</span>
+      <%= link_to "利用規約", terms_path, class: "text-gray-700 hover:text-orange-600 transition-colors" %>
     </div>
-  </footer>
-  
+    <p class="text-gray-600">&copy; 2026 <%= t('app_name') %></p>
+  </div>
+</footer>

--- a/app/views/shared/_guest_header.html.erb
+++ b/app/views/shared/_guest_header.html.erb
@@ -1,15 +1,35 @@
 <header class="navbar bg-white shadow-md">
-  <div class="flex-1">
+  <%# モバイル: ハンバーガー + アプリ名 %>
+  <div class="navbar-start">
+    <div class="dropdown">
+      <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" />
+        </svg>
+      </div>
+      <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-white rounded-box w-52">
+        <li><%= link_to "使い方", how_to_use_path, class: "text-gray-700 hover:text-orange-600" %></li>
+        <li><%= link_to "みんなのハレ", public_hare_entries_path, class: "text-gray-700 hover:text-orange-600" %></li>
+        <li><%= link_to "ログイン", new_user_session_path, class: "text-gray-700 hover:text-orange-600" %></li>
+        <li>
+          <%= link_to "新規登録", new_user_registration_path, class: "btn bg-orange-600 hover:bg-orange-700 text-white btn-sm border-0 w-full mt-1" %>
+        </li>
+      </ul>
+    </div>
     <%= link_to t('app_name'), root_path, class: "text-xl font-bold text-gray-900" %>
   </div>
-  <nav class="flex-none">
+
+  <%# デスクトップ: 横並びメニュー %>
+  <div class="navbar-center hidden lg:flex">
     <ul class="menu menu-horizontal px-1 space-x-2">
       <li><%= link_to "使い方", how_to_use_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
       <li><%= link_to "みんなのハレ", public_hare_entries_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
       <li><%= link_to "ログイン", new_user_session_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
-      <li>
-        <%= link_to "新規登録", new_user_registration_path, class: "btn bg-orange-600 hover:bg-orange-700 text-white btn-sm border-0" %>
-      </li>
     </ul>
-  </nav>
+  </div>
+
+  <%# 新規登録ボタン %>
+  <div class="navbar-end hidden lg:flex">
+    <%= link_to "新規登録", new_user_registration_path, class: "btn bg-orange-600 hover:bg-orange-700 text-white btn-sm border-0" %>
+  </div>
 </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,18 +1,41 @@
-  <header class="navbar bg-white shadow-md">
-    <div class="flex-1">
-      <%= link_to t('app_name'), root_path, class: "text-xl font-bold text-gray-900" %>
-    </div>
-    <nav class="flex-none">
-      <ul class="menu menu-horizontal px-1 space-x-2">
-        <li><%= link_to "ホーム", home_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
-        <li><%= link_to "カレンダー", calendar_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
-        <li><%= link_to "献立相談", new_meal_search_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
-        <li><%= link_to "みんなのハレ", public_hare_entries_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
-        <li><%= link_to "ハレ投稿", new_hare_entry_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
-        <li><%= link_to "プロフィール", profile_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
+<header class="navbar bg-white shadow-md">
+  <%# モバイル: ハンバーガー + アプリ名 %>
+  <div class="navbar-start">
+    <div class="dropdown">
+      <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" />
+        </svg>
+      </div>
+      <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-white rounded-box w-52">
+        <li><%= link_to "ホーム", home_path, class: "text-gray-700 hover:text-orange-600" %></li>
+        <li><%= link_to "カレンダー", calendar_path, class: "text-gray-700 hover:text-orange-600" %></li>
+        <li><%= link_to "献立相談", new_meal_search_path, class: "text-gray-700 hover:text-orange-600" %></li>
+        <li><%= link_to "みんなのハレ", public_hare_entries_path, class: "text-gray-700 hover:text-orange-600" %></li>
+        <li><%= link_to "ハレ投稿", new_hare_entry_path, class: "text-gray-700 hover:text-orange-600" %></li>
+        <li><%= link_to "プロフィール", profile_path, class: "text-gray-700 hover:text-orange-600" %></li>
         <li>
-          <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn bg-orange-600 hover:bg-orange-700 text-white btn-sm border-0" %>
+          <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn bg-orange-600 hover:bg-orange-700 text-white btn-sm border-0 w-full mt-1" %>
         </li>
       </ul>
-    </nav>
-  </header>
+    </div>
+    <%= link_to t('app_name'), root_path, class: "text-xl font-bold text-gray-900" %>
+  </div>
+
+  <%# デスクトップ: 横並びメニュー %>
+  <div class="navbar-center hidden lg:flex">
+    <ul class="menu menu-horizontal px-1 space-x-2">
+      <li><%= link_to "ホーム", home_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
+      <li><%= link_to "カレンダー", calendar_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
+      <li><%= link_to "献立相談", new_meal_search_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
+      <li><%= link_to "みんなのハレ", public_hare_entries_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
+      <li><%= link_to "ハレ投稿", new_hare_entry_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
+      <li><%= link_to "プロフィール", profile_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
+    </ul>
+  </div>
+
+  <%# ログアウトボタン %>
+  <div class="navbar-end hidden lg:flex">
+    <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn bg-orange-600 hover:bg-orange-700 text-white btn-sm border-0" %>
+  </div>
+</header>


### PR DESCRIPTION
## 概要
ケハレ帖のモバイル表示を全面改善。スマホ中心ユーザーをターゲットにしたアプリに相応しいレスポンシブデザインを実装。

## 関連 Issue
closes #145

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/views/shared/_header.html.erb` | 変更 | daisyUIハンバーガーメニュー追加 |
| `app/views/shared/_guest_header.html.erb` | 変更 | 同上（ゲスト用） |
| `app/views/shared/_footer.html.erb` | 変更 | flex flex-wrapでリンク折り返し対応 |
| `app/views/home/index.html.erb` | 変更 | アクションカードのabsolute→flex配置変更、文字サイズ・画像サイズ調整 |
| `app/views/hare_entries/index.html.erb` | 変更 | MATHLYカードをflex-col sm:flex-rowに変更 |
| `app/views/hare_entries/_form.html.erb` | 変更 | 画像max-w-full追加、ボタンflex-col sm:flex-row |
| `app/views/hare_entries/show.html.erb` | 変更 | ヘッダーをflex-col sm:flex-rowに変更 |
| `app/views/hare_entries/public.html.erb` | 変更 | 画像max-w-full追加、break-words追加 |
| `app/views/hare_entries/new.html.erb` | 変更 | p-8→p-4 md:p-8 |
| `app/views/hare_entries/edit.html.erb` | 変更 | p-8→p-4 md:p-8 |
| `app/views/meal_searches/new.html.erb` | 変更 | ラジオボタンをflex-col sm:flex-rowに |
| `app/views/meal_searches/index.html.erb` | 変更 | ページヘッダーをflex-col sm:flex-rowに |
| `app/views/profiles/show.html.erb` | 変更 | break-all・イラストサイズ・情報行flex-colに |
| `app/views/calendar/index.html.erb` | 変更 | セル高さh-[80px] md:h-[120px]に |
| `app/views/calendar/show.html.erb` | 変更 | 見出しtext-xl md:text-3xlに |
| `app/assets/stylesheets/application.tailwind.css` | 変更 | カレンダーmin-w-[500px]追加 |
| `app/views/devise/confirmations/new.html.erb` | 変更 | sessions/newスタイルに統一 |
| `app/views/devise/unlocks/new.html.erb` | 変更 | sessions/newスタイルに統一 |

## 実装のポイント
- **ハンバーガーメニュー**: daisyUI dropdown + tabindex/role="button" でJS不要のアクセシブルな実装
- **ブレークポイント**: `lg:`（1024px）でデスクトップ/モバイルを切り替え
- **パディング段階化**: `p-4 md:p-8` パターンを全ページに統一適用
- **アクションカード**: `absolute bottom-8 right-8` → `flex flex-col` + `mt-auto` でレイアウトフロー内に配置
- **カレンダー**: `min-w-[500px]` + `overflow-x-auto`（既存）で横スクロール対応

## テスト計画
- [ ] RSpec 520件 全パス確認済み
- [ ] モバイルビュー（375px）でヘッダーのハンバーガーメニュー動作確認
- [ ] デスクトップ（1024px+）で従来通りの表示確認

## 残件・TODO
- なし