### PR TITLE
[Security] SSL の有効化（assume_ssl / force_ssl）

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,13 +25,13 @@ Rails.application.configure do
   config.active_storage.service = :cloudinary
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
## 概要
- `assume_ssl = true` を有効化（Render の SSL 終端環境でRailsがHTTPSとして認識）
- `force_ssl = true` を有効化（HSTS・Secure Cookie・HTTP→HTTPSリダイレクト）
- `/up` ヘルスチェックをSSLリダイレクト対象から除外

## 関連 Issue
closes #153

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `config/environments/production.rb` | 修正 | SSL 設定3行のコメントアウト解除 |

## 実装のポイント
- コメントアウト解除のみ。Rails 8 デフォルト設定をそのまま有効化
- `ssl_options` の `/up` 除外により Render のヘルスチェックが HTTP のまま通過可能

## テスト計画
- [ ] CI（RSpec・RuboCop）通過確認
- [ ] デプロイ後: https:// でアクセス確認・Secure Cookie 確認

## 残件・TODO
- なし（#155 Host Authorization、#154 rack-attack は別 PR で対応）