### PR TITLE
[Security] Host Authorization の有効化（DNS Rebinding 対策）

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,11 +86,10 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  config.hosts = [
+    "kehare-cho.onrender.com"
+  ]
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## 概要
- `config.hosts` に `kehare-cho.onrender.com` を登録
- 許可リスト外の `Host` ヘッダーを持つリクエストを 403 で拒否
- `/up` ヘルスチェックを検証対象から除外

## 関連 Issue
closes #155

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `config/environments/production.rb` | 修正 | Host Authorization 設定のコメントアウト解除・ドメイン設定 |

## 実装のポイント
- デフォルトの `example.com` を `kehare-cho.onrender.com` に変更
- サブドメイン用の正規表現行は不要なため削除
- `/up` 除外設定はヘルスチェック（IP アドレスアクセス）のため必須

## テスト計画
- [x] CI（RSpec・RuboCop）通過確認
- [x] デプロイ後: 正規ドメインでアクセス確認・不正ドメインが 403 になることを確認

## 残件・TODO
- なし（#154 rack-attack は別 PR で対応）