### PR TITLE
[Security] rack-attack 導入（Rate Limiting・ブルートフォース対策）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem "kaminari"
 # メール送信 API（本番環境用）[https://github.com/resend/resend-ruby]
 gem "resend"
 
+# レートリミット・ブルートフォース対策 [https://github.com/rack/rack-attack]
+gem "rack-attack"
+
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,6 +303,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.5)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -523,6 +525,7 @@ DEPENDENCIES
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)
+  rack-attack
   rails (~> 8.1.2)
   rails-controller-testing
   rails-i18n (~> 8.0)
@@ -670,6 +673,7 @@ CHECKSUMS
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.5) sha256=4cbd0974c0b79f7a139b4812004a62e4c60b145cba76422e288ee670601ed6d3
+  rack-attack (6.8.0) sha256=f2499fdebf85bcc05573a22dff57d24305ac14ec2e4156cd3c28d47cafeeecf2
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,25 @@
+# ログイン試行を IP アドレスで制限（1分間に5回まで）
+Rack::Attack.throttle("logins/ip", limit: 5, period: 1.minute) do |request|
+  request.ip if request.path == "/users/sign_in" && request.post?
+end
+
+# ログイン試行をメールアドレスで制限（1分間に5回まで）
+Rack::Attack.throttle("logins/email", limit: 5, period: 1.minute) do |request|
+  if request.path == "/users/sign_in" && request.post?
+    request.params.dig("user", "email")&.downcase&.strip
+  end
+end
+
+# 全リクエストを IP アドレスで制限（5分間に300回まで）
+Rack::Attack.throttle("req/ip", limit: 300, period: 5.minutes) do |request|
+  request.ip unless request.path.start_with?("/assets")
+end
+
+# 429 レスポンスを日本語でカスタマイズ
+Rack::Attack.throttled_responder = lambda do |_request|
+  [
+    429,
+    { "Content-Type" => "text/plain; charset=utf-8" },
+    [ "リクエストが多すぎます。しばらく時間をおいてから再度お試しください。\n" ]
+  ]
+end


### PR DESCRIPTION
## 概要
- `rack-attack` gem を導入し、Rate Limiting を実装
- ブルートフォース攻撃・クレデンシャルスタッフィング・DoS 攻撃を防ぐ

## 関連 Issue
closes #154

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `Gemfile` | 修正 | rack-attack gem を追加 |
| `Gemfile.lock` | 修正 | rack-attack 6.8.0 を追加 |
| `config/initializers/rack_attack.rb` | 追加 | Rate Limiting ルールを定義 |

## 実装のポイント
- ログイン試行は IP・メールアドレスの両方で制限（回避策を防ぐ）
- アセットへのリクエストは全体制限から除外
- 429 レスポンスを日本語化

## スロットルルール一覧
| ルール名 | 対象 | 制限 | Key |
|---------|------|------|-----|
| `logins/ip` | `POST /users/sign_in` | 5回/分 | IP |
| `logins/email` | `POST /users/sign_in` | 5回/分 | メールアドレス |
| `req/ip` | 全リクエスト | 300回/5分 | IP |

## テスト計画
- [ ] CI（RSpec・RuboCop）通過確認

## 残件・TODO
- なし（Phase 1 完了。次は Phase 2: #156 OGP 対応）