### PR TITLE
[Infra] デプロイ時の db:migrate 自動実行

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -3,5 +3,6 @@ set -e
 
 # DockerfileのWORKDIR=/app に合わせる
 rm -f /app/tmp/pids/server.pid
+bundle exec rails db:migrate
 
 exec "$@"


### PR DESCRIPTION
## 概要
- `bin/docker-entrypoint` に `bundle exec rails db:migrate` を追加
- コンテナ起動時にマイグレーションが自動実行されるようになる

## 関連 Issue
closes #163

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `bin/docker-entrypoint` | 修正 | マイグレーション自動実行を追加 |

## 実装のポイント
- `set -e` が有効なため、マイグレーション失敗時はサーバーが起動しない（安全）
- `db:migrate` は冪等なので、コンテナが再起動されても問題なし
- Rails の Advisory Lock により、複数インスタンスの同時実行も安全

## 残件・TODO
- なし