### PR TITLE
[UI] ハレ投稿フォームに文字数カウンターを追加

### DIFF
--- a/app/javascript/controllers/character_count_controller.js
+++ b/app/javascript/controllers/character_count_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+// テキストエリアの残り文字数をリアルタイム表示する Stimulus コントローラー
+// 使い方: data-controller="character-count" を親要素に追加
+export default class extends Controller {
+  static targets = ["input", "count"]
+
+  // コントローラーが接続されたとき（ページ読み込み時）に呼ばれる
+  // 編集フォームで既存テキストがある場合の初期カウントを表示する
+  connect() {
+    this.update()
+  }
+
+  // input イベントで呼ばれるメソッド
+  // data-action="input->character-count#update" で紐付け
+  update() {
+    const current = this.inputTarget.value.length
+    const max = this.inputTarget.maxLength
+    const remaining = max - current
+
+    this.countTarget.textContent = remaining
+    this.#updateColor(remaining)
+  }
+
+  // 残り文字数に応じてカウント表示の色を切り替える
+  #updateColor(remaining) {
+    this.countTarget.classList.remove("text-gray-400", "text-orange-500", "text-red-500")
+
+    if (remaining <= 0) {
+      this.countTarget.classList.add("text-red-500")
+    } else if (remaining <= 20) {
+      this.countTarget.classList.add("text-orange-500")
+    } else {
+      this.countTarget.classList.add("text-gray-400")
+    }
+  }
+}

--- a/app/views/hare_entries/_form.html.erb
+++ b/app/views/hare_entries/_form.html.erb
@@ -12,9 +12,12 @@
   <% end %>
 
   <%# 内容入力 %>
-  <div>
+  <div data-controller="character-count">
     <%= f.label :body, "内容", class: "block text-base font-bold text-gray-800 mb-3" %>
-    <%= f.text_area :body, class: "w-full px-4 py-3 bg-gray-50 border-2 border-gray-300 rounded-xl focus:ring-2 focus:ring-orange-400 focus:border-orange-400 focus:bg-white resize-none text-gray-900 placeholder-gray-500", rows: 6, maxlength: 280, placeholder: "今日のごはんで「ちょっと特別」だったことは？（280文字まで）" %>
+    <%= f.text_area :body, class: "w-full px-4 py-3 bg-gray-50 border-2 border-gray-300 rounded-xl focus:ring-2 focus:ring-orange-400 focus:border-orange-400 focus:bg-white resize-none text-gray-900 placeholder-gray-500", rows: 6, maxlength: 280, placeholder: "今日のごはんで「ちょっと特別」だったことは？（280文字まで）", data: { character_count_target: "input", action: "input->character-count#update" } %>
+    <p class="text-right text-sm mt-1">
+      残り <span data-character-count-target="count" class="font-semibold text-gray-400">280</span> 文字
+    </p>
   </div>
 
   <%# 日付入力 %>


### PR DESCRIPTION
## 概要
- Stimulus コントローラー `character_count_controller.js` を新規作成
- テキストエリア入力時に残り文字数をリアルタイム表示
- 残り 20 文字以下でオレンジ、0 文字でレッドに色変化

## 関連 Issue
closes #167

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/javascript/controllers/character_count_controller.js` | 新規 | 文字数カウンター Stimulus コントローラー |
| `app/views/hare_entries/_form.html.erb` | 修正 | data-controller・target・action を追加、カウント表示 span を追加 |

## 実装のポイント
- `connect()` で編集フォームを開いた際の初期カウントを表示
- `maxLength` を HTML 属性から読み取り（ハードコードなし）
- プライベートメソッド `#updateColor` で色変化ロジックを分離
- `image_preview_controller.js` と同じパターンで統一

## 残件・TODO
- なし