### PR TITLE
[Fix] 文字数カウンターの視認性を改善

### DIFF
--- a/app/javascript/controllers/character_count_controller.js
+++ b/app/javascript/controllers/character_count_controller.js
@@ -24,14 +24,14 @@ export default class extends Controller {
 
   // 残り文字数に応じてカウント表示の色を切り替える
   #updateColor(remaining) {
-    this.countTarget.classList.remove("text-gray-400", "text-orange-500", "text-red-500")
+    this.countTarget.classList.remove("text-gray-600", "text-orange-500", "text-red-500")
 
     if (remaining <= 0) {
       this.countTarget.classList.add("text-red-500")
     } else if (remaining <= 20) {
       this.countTarget.classList.add("text-orange-500")
     } else {
-      this.countTarget.classList.add("text-gray-400")
+      this.countTarget.classList.add("text-gray-600")
     }
   }
 }

--- a/app/views/hare_entries/_form.html.erb
+++ b/app/views/hare_entries/_form.html.erb
@@ -16,7 +16,7 @@
     <%= f.label :body, "内容", class: "block text-base font-bold text-gray-800 mb-3" %>
     <%= f.text_area :body, class: "w-full px-4 py-3 bg-gray-50 border-2 border-gray-300 rounded-xl focus:ring-2 focus:ring-orange-400 focus:border-orange-400 focus:bg-white resize-none text-gray-900 placeholder-gray-500", rows: 6, maxlength: 280, placeholder: "今日のごはんで「ちょっと特別」だったことは？（280文字まで）", data: { character_count_target: "input", action: "input->character-count#update" } %>
     <p class="text-right text-sm mt-1">
-      残り <span data-character-count-target="count" class="font-semibold text-gray-400">280</span> 文字
+      残り <span data-character-count-target="count" class="font-semibold text-gray-600">280</span> 文字
     </p>
   </div>
 


### PR DESCRIPTION
## 概要
- 文字数カウンター通常時の色を `text-gray-400` → `text-gray-600` に変更
- フォーム背景（`bg-gray-50`）と同化して見えにくかった問題を修正

## 関連 Issue
- #167 の不具合修正

## 変更ファイル一覧
| ファイル | 種別 | 変更内容 |
|---------|------|---------|
| `app/javascript/controllers/character_count_controller.js` | 修正 | 通常時の色クラスを変更 |
| `app/views/hare_entries/_form.html.erb` | 修正 | span の初期クラスを変更 |

## 残件・TODO
- なし