### PR TITLE
[Feature] 中食検索のUX改善とmood_keywordバグ修正

### DIFF
--- a/app/controllers/meal_searches_controller.rb
+++ b/app/controllers/meal_searches_controller.rb
@@ -18,14 +18,16 @@ class MealSearchesController < ApplicationController
   def create
     if params[:cook_context] == "eat_out"
       # 外食の処理
+      genre = Genre.find(params[:genre_id])
       current_user.meal_searches.create!(
         cook_context: params[:cook_context],
         genre_id: params[:genre_id],
         presented_candidate_names: []
       )
 
-      url = GoogleMapsQueryBuilder.new(params[:genre_id], params[:mood_tag_id]).url
-      redirect_to url, allow_other_host: true
+      @maps_url = GoogleMapsQueryBuilder.new(params[:genre_id], params[:mood_tag_id]).url
+      @genre_label = genre.label
+      render :redirect_to_maps
     else
       # 自炊の処理
       genre_id = params[:genre_id]

--- a/app/javascript/controllers/maps_redirect_controller.js
+++ b/app/javascript/controllers/maps_redirect_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 中食選択時に Google Maps へ自動リダイレクトする Stimulus コントローラー
+// 使い方: data-controller="maps-redirect" data-maps-redirect-url-value="<URL>" を要素に追加
+export default class extends Controller {
+  static values = { url: String }
+
+  connect() {
+    // 2秒後に Google Maps へ自動遷移
+    this.timer = setTimeout(() => {
+      window.location.href = this.urlValue
+    }, 2000)
+  }
+
+  disconnect() {
+    clearTimeout(this.timer)
+  }
+}

--- a/app/services/google_maps_query_builder.rb
+++ b/app/services/google_maps_query_builder.rb
@@ -20,10 +20,18 @@ class GoogleMapsQueryBuilder
 
     def mood_keyword
       case @mood.key
-      when "energetic"
-        "ボリューム"
-      when "relaxed"
+      when "light"
+        "さっぱり"
+      when "rich"
+        "こってり"
+      when "warm"
+        "あったかい"
+      when "hearty"
+        "がっつり"
+      when "healthy"
         "ヘルシー"
+      when "easy"
+        "簡単"
       end
     end
 end

--- a/app/views/meal_searches/redirect_to_maps.html.erb
+++ b/app/views/meal_searches/redirect_to_maps.html.erb
@@ -1,0 +1,34 @@
+<main class="max-w-3xl mx-auto p-4 md:p-8">
+  <%# 自動リダイレクト処理 %>
+  <div data-controller="maps-redirect" data-maps-redirect-url-value="<%= @maps_url %>">
+    <%# ページヘッダー %>
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-3xl font-bold text-gray-800 mb-2">献立相談</h1>
+        <p class="text-gray-600">今日のごはん、何にしますか？ 🍚</p>
+      </div>
+      <%= link_to "ホーム", home_path, class: "text-gray-600 hover:text-gray-800 font-medium" %>
+    </div>
+
+    <%# メッセージカード %>
+    <div class="bg-white rounded-2xl shadow-sm p-8 text-center">
+      <p class="text-2xl mb-2">🗺️</p>
+      <h2 class="text-xl font-bold text-gray-800 mb-2">近くのお店を探しています...</h2>
+      <p class="text-gray-600 mb-6">
+        <span class="font-semibold text-orange-600"><%= @genre_label %></span> のお店を Google マップで検索します
+      </p>
+
+      <%# ローディングアニメーション %>
+      <div class="flex justify-center mb-8">
+        <span class="loading loading-dots loading-lg text-orange-400"></span>
+      </div>
+
+      <%# 手動リンク（フォールバック） %>
+      <p class="text-sm text-gray-500">
+        自動で移動しない場合は
+        <%= link_to "こちら", @maps_url, class: "text-orange-500 hover:text-orange-600 underline font-medium" %>
+        をクリックしてください
+      </p>
+    </div>
+  </div>
+</main>

--- a/spec/requests/meal_searches_spec.rb
+++ b/spec/requests/meal_searches_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "MealSearches", type: :request do
 
       it "気分タグの選択肢が表示される" do
         # seedデータから気分タグを作成
-        mood1 = MoodTag.find_or_create_by(key: "energetic") { |m| m.label = "元気を出したい" }
-        mood2 = MoodTag.find_or_create_by(key: "relaxed") { |m| m.label = "リラックスしたい" }
+        mood1 = MoodTag.find_or_create_by(key: "light") { |m| m.label = "さっぱり" }
+        mood2 = MoodTag.find_or_create_by(key: "rich") { |m| m.label = "こってり" }
 
         get new_meal_search_path
         expect(response.body).to include(mood1.label)
@@ -269,56 +269,64 @@ RSpec.describe "MealSearches", type: :request do
 
   describe "POST /meal_searches (外食選択時)" do
     let(:genre) { Genre.find_or_create_by(key: "japanese") { |g| g.label = "和食" } }
-    let(:mood) { MoodTag.find_or_create_by(key: "energetic") { |m| m.label = "がっつり食べたい" } }
+    let(:mood) { MoodTag.find_or_create_by(key: "hearty") { |m| m.label = "がっつり" } }
 
     context "ログイン済みユーザーの場合" do
       before { sign_in user }
 
       context "外食を選択した場合" do
-        it "Google Mapsにリダイレクトする" do
+        it "中間ページ（200）を返す" do
           post meal_searches_path, params: {
             cook_context: "eat_out",
             genre_id: genre.id
           }
 
-          expect(response).to have_http_status(:redirect)
-          expect(response.location).to include("google.com/maps/search/")
+          expect(response).to have_http_status(:ok)
         end
 
-        it "リダイレクト先のURLにapi=1パラメータが含まれる" do
+        it "中間ページに Google Maps の URL が含まれる" do
           post meal_searches_path, params: {
             cook_context: "eat_out",
             genre_id: genre.id
           }
 
-          expect(response.location).to include("api=1")
+          expect(response.body).to include("google.com/maps/search/")
         end
 
-        it "リダイレクト先のURLにジャンル名が含まれる" do
+        it "中間ページに api=1 パラメータが含まれる" do
           post meal_searches_path, params: {
             cook_context: "eat_out",
             genre_id: genre.id
           }
 
-          expect(response.location).to include(CGI.escape("和食"))
+          expect(response.body).to include("api=1")
         end
 
-        it "リダイレクト先のURLに「惣菜」が含まれる" do
+        it "中間ページにジャンル名が含まれる" do
           post meal_searches_path, params: {
             cook_context: "eat_out",
             genre_id: genre.id
           }
 
-          expect(response.location).to include(CGI.escape("惣菜"))
+          expect(response.body).to include(CGI.escape("和食"))
         end
 
-        it "リダイレクト先のURLに「定食」が含まれる" do
+        it "中間ページに「惣菜」が含まれる" do
           post meal_searches_path, params: {
             cook_context: "eat_out",
             genre_id: genre.id
           }
 
-          expect(response.location).to include(CGI.escape("定食"))
+          expect(response.body).to include(CGI.escape("惣菜"))
+        end
+
+        it "中間ページに「定食」が含まれる" do
+          post meal_searches_path, params: {
+            cook_context: "eat_out",
+            genre_id: genre.id
+          }
+
+          expect(response.body).to include(CGI.escape("定食"))
         end
 
         it "検索ログ（MealSearch）が作成される" do
@@ -359,15 +367,24 @@ RSpec.describe "MealSearches", type: :request do
           expect(session[:meal_candidates]).to be_nil
         end
 
+        it "中間ページにローディングメッセージが含まれる" do
+          post meal_searches_path, params: {
+            cook_context: "eat_out",
+            genre_id: genre.id
+          }
+
+          expect(response.body).to include("近くのお店を探しています")
+        end
+
         context "気分タグも指定した場合" do
-          it "リダイレクト先のURLに気分タグのキーワードが含まれる" do
+          it "中間ページに気分タグのキーワードが含まれる" do
             post meal_searches_path, params: {
               cook_context: "eat_out",
               genre_id: genre.id,
               mood_tag_id: mood.id
             }
 
-            expect(response.location).to include(CGI.escape("ボリューム"))
+            expect(response.body).to include(CGI.escape("がっつり"))
           end
         end
       end

--- a/spec/services/google_maps_query_builder_spec.rb
+++ b/spec/services/google_maps_query_builder_spec.rb
@@ -35,20 +35,52 @@ RSpec.describe GoogleMapsQueryBuilder do
     end
 
     context "ジャンルIDと気分タグIDを指定した場合" do
-      it "URLに気分タグのキーワードが含まれる（energetic）" do
+      it "URLに気分タグのキーワードが含まれる（light → さっぱり）" do
         genre = Genre.find_or_create_by(key: "japanese") { |g| g.label = "和食" }
-        mood = MoodTag.find_or_create_by(key: "energetic") { |m| m.label = "がっつり食べたい" }
+        mood = MoodTag.find_or_create_by(key: "light") { |m| m.label = "さっぱり" }
         builder = GoogleMapsQueryBuilder.new(genre.id, mood.id)
 
-        expect(builder.url).to include(CGI.escape("ボリューム"))
+        expect(builder.url).to include(CGI.escape("さっぱり"))
       end
 
-      it "URLに気分タグのキーワードが含まれる（relaxed）" do
+      it "URLに気分タグのキーワードが含まれる（rich → こってり）" do
         genre = Genre.find_or_create_by(key: "japanese") { |g| g.label = "和食" }
-        mood = MoodTag.find_or_create_by(key: "relaxed") { |m| m.label = "リラックスしたい" }
+        mood = MoodTag.find_or_create_by(key: "rich") { |m| m.label = "こってり" }
+        builder = GoogleMapsQueryBuilder.new(genre.id, mood.id)
+
+        expect(builder.url).to include(CGI.escape("こってり"))
+      end
+
+      it "URLに気分タグのキーワードが含まれる（warm → あったかい）" do
+        genre = Genre.find_or_create_by(key: "japanese") { |g| g.label = "和食" }
+        mood = MoodTag.find_or_create_by(key: "warm") { |m| m.label = "あったかい" }
+        builder = GoogleMapsQueryBuilder.new(genre.id, mood.id)
+
+        expect(builder.url).to include(CGI.escape("あったかい"))
+      end
+
+      it "URLに気分タグのキーワードが含まれる（hearty → がっつり）" do
+        genre = Genre.find_or_create_by(key: "japanese") { |g| g.label = "和食" }
+        mood = MoodTag.find_or_create_by(key: "hearty") { |m| m.label = "がっつり" }
+        builder = GoogleMapsQueryBuilder.new(genre.id, mood.id)
+
+        expect(builder.url).to include(CGI.escape("がっつり"))
+      end
+
+      it "URLに気分タグのキーワードが含まれる（healthy → ヘルシー）" do
+        genre = Genre.find_or_create_by(key: "japanese") { |g| g.label = "和食" }
+        mood = MoodTag.find_or_create_by(key: "healthy") { |m| m.label = "ヘルシー" }
         builder = GoogleMapsQueryBuilder.new(genre.id, mood.id)
 
         expect(builder.url).to include(CGI.escape("ヘルシー"))
+      end
+
+      it "URLに気分タグのキーワードが含まれる（easy → 簡単）" do
+        genre = Genre.find_or_create_by(key: "japanese") { |g| g.label = "和食" }
+        mood = MoodTag.find_or_create_by(key: "easy") { |m| m.label = "簡単" }
+        builder = GoogleMapsQueryBuilder.new(genre.id, mood.id)
+
+        expect(builder.url).to include(CGI.escape("簡単"))
       end
     end
 
@@ -72,10 +104,10 @@ RSpec.describe GoogleMapsQueryBuilder do
 
     it "気分タグがある場合、キーワードが追加される" do
       genre = Genre.find_or_create_by(key: "japanese") { |g| g.label = "和食" }
-      mood = MoodTag.find_or_create_by(key: "energetic") { |m| m.label = "がっつり食べたい" }
+      mood = MoodTag.find_or_create_by(key: "hearty") { |m| m.label = "がっつり" }
       builder = GoogleMapsQueryBuilder.new(genre.id, mood.id)
 
-      expect(builder.query).to eq(CGI.escape("和食 惣菜 定食 ボリューム"))
+      expect(builder.query).to eq(CGI.escape("和食 惣菜 定食 がっつり"))
     end
 
     it "特殊文字が正しくエスケープされる" do


### PR DESCRIPTION
## 概要
- `GoogleMapsQueryBuilder#mood_keyword` のバグ修正（マッピングキーが実際の seed データと不一致）
- 中食（eat_out）選択時にリダイレクト前の中間ページを表示する UX 改善

## 関連 Issue
closes #113

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/services/google_maps_query_builder.rb` | 修正 | mood_keyword のキーを実際の seed データ（light/rich/warm/hearty/healthy/easy）に合わせる |
| `app/controllers/meal_searches_controller.rb` | 修正 | eat_out 分岐で redirect_to → render :redirect_to_maps に変更 |
| `app/views/meal_searches/redirect_to_maps.html.erb` | 新規 | ローディングメッセージ + 自動リダイレクト画面 |
| `app/javascript/controllers/maps_redirect_controller.js` | 新規 | 2秒後に Google Maps へ自動遷移する Stimulus コントローラー |
| `spec/requests/meal_searches_spec.rb` | 修正 | mood キーを seed 実態に合わせ修正、中間ページ表示のテストに変更 |
| `spec/services/google_maps_query_builder_spec.rb` | 修正 | 全 6 種の mood キーをテスト対象に追加 |

## 実装のポイント

### バグ修正
Issue #108 実装時に `mood_keyword` のマッピングが `energetic`/`relaxed` だったが、実際の seed データは `light`, `rich`, `warm`, `hearty`, `healthy`, `easy` を使用。キーが一致しないため気分タグが Google Maps 検索に反映されない状態だった。

### 中間ページ
- Stimulus コントローラー（`maps-redirect`）が `connect()` で `setTimeout` を設定し、2秒後に `window.location.href` で外部遷移
- `disconnect()` で `clearTimeout` によるクリーンアップ
- daisyUI の `loading-dots` でローディングアニメーションを表現
- フォールバックリンク（「こちら」）で自動遷移しない場合も対応

## テスト計画
- [x] `spec/services/google_maps_query_builder_spec.rb` — 全 6 mood キーのテストが通ること
- [x] `spec/requests/meal_searches_spec.rb` — 中間ページの表示テスト（200 OK、URL・メッセージ含有）

## 残件・TODO
- なし