### PR TITLE
[Feature] 新規登録後のオンボーディング導線を整備

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,5 +12,9 @@ module Users
         end
       end
     end
+
+    def after_sign_up_path_for(resource)
+      how_to_use_path
+    end
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -80,6 +80,7 @@
       <div class="flex gap-4 justify-center text-sm">
         <%= link_to "ハレ一覧", hare_entries_path, class: "text-gray-600 hover:text-gray-800 underline" %>
         <%= link_to "献立ログ", meal_searches_path, class: "text-gray-600 hover:text-gray-800 underline" %>
+        <%= link_to "使い方", how_to_use_path, class: "text-gray-600 hover:text-gray-800 underline" %>
       </div>
     </main>
   <% else %>

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe "Users::Registrations", type: :request do
         }.to change(User, :count).by(1)
       end
 
-      it "root_path にリダイレクトされる" do
+      it "how_to_use_path にリダイレクトされる" do
         post user_registration_path, params: valid_params
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(how_to_use_path)
       end
 
       it "ログイン状態になる" do

--- a/spec/system/user_registration_spec.rb
+++ b/spec/system/user_registration_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe "ユーザー登録", type: :system do
 
     click_button "アカウント登録"
 
-    # 登録成功 → ホーム画面にリダイレクト＋フラッシュ
+    # 登録成功 → 使い方ページにリダイレクト＋フラッシュ
+    expect(page).to have_current_path(how_to_use_path)
     expect(page).to have_text("ようこそケハレ帖へ！")
-    expect(page).to have_text("こんにちは、新規ユーザー さん")
+    expect(page).to have_text("ケハレ帖の使い方")
   end
 end


### PR DESCRIPTION
## 概要
新規登録後にいきなりホームへ遷移していた問題を解消し、初回ユーザーが「使い方」を把握できる導線を整備した。

## 関連 Issue
closes #170

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/controllers/users/registrations_controller.rb` | 変更 | `after_sign_up_path_for` を追加し、登録後に `how_to_use_path` へリダイレクト |
| `app/views/home/index.html.erb` | 変更 | 下部リンクエリアに「使い方」リンクを追加 |
| `spec/requests/users/registrations_spec.rb` | 変更 | リダイレクト先を `how_to_use_path` に更新 |
| `spec/system/user_registration_spec.rb` | 変更 | 遷移先と表示テキストの期待値を更新 |

## 実装のポイント
- Devise の `after_sign_up_path_for` をオーバーライドして登録後のリダイレクト先を変更
- 既存ユーザーのログインには影響なし（`after_sign_in_path_for` は変更していない）
- ホームの下部リンクに「使い方」を追加し、登録済みユーザーも使い方ページへ辿れるようにした

## テスト計画
- [x] 新規登録後に `how_to_use_path` へリダイレクトされること
- [x] フラッシュメッセージ「ようこそケハレ帖へ！」が表示されること
- [x] ホームに「使い方」リンクが表示されること
- [x] 全 539 件のテスト通過

## 残件・TODO
- なし