### PR TITLE
[UI] ヘッダーナビにアクティブ状態のスタイルを追加

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,12 +8,12 @@
         </svg>
       </div>
       <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-white rounded-box w-52">
-        <li><%= link_to "ホーム", home_path, class: "text-gray-700 hover:text-orange-600" %></li>
-        <li><%= link_to "カレンダー", calendar_path, class: "text-gray-700 hover:text-orange-600" %></li>
-        <li><%= link_to "献立相談", new_meal_search_path, class: "text-gray-700 hover:text-orange-600" %></li>
-        <li><%= link_to "みんなのハレ", public_hare_entries_path, class: "text-gray-700 hover:text-orange-600" %></li>
-        <li><%= link_to "ハレ投稿", new_hare_entry_path, class: "text-gray-700 hover:text-orange-600" %></li>
-        <li><%= link_to "プロフィール", profile_path, class: "text-gray-700 hover:text-orange-600" %></li>
+        <li><%= link_to "ホーム", home_path, class: "#{current_page?(home_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
+        <li><%= link_to "カレンダー", calendar_path, class: "#{current_page?(calendar_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
+        <li><%= link_to "献立相談", new_meal_search_path, class: "#{current_page?(new_meal_search_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
+        <li><%= link_to "みんなのハレ", public_hare_entries_path, class: "#{current_page?(public_hare_entries_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
+        <li><%= link_to "ハレ投稿", new_hare_entry_path, class: "#{current_page?(new_hare_entry_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
+        <li><%= link_to "プロフィール", profile_path, class: "#{current_page?(profile_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
         <li>
           <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn bg-orange-600 hover:bg-orange-700 text-white btn-sm border-0 w-full mt-1" %>
         </li>
@@ -25,12 +25,12 @@
   <%# デスクトップ: 横並びメニュー %>
   <div class="navbar-center hidden lg:flex">
     <ul class="menu menu-horizontal px-1 space-x-2">
-      <li><%= link_to "ホーム", home_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
-      <li><%= link_to "カレンダー", calendar_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
-      <li><%= link_to "献立相談", new_meal_search_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
-      <li><%= link_to "みんなのハレ", public_hare_entries_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
-      <li><%= link_to "ハレ投稿", new_hare_entry_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
-      <li><%= link_to "プロフィール", profile_path, class: "btn btn-ghost btn-sm text-gray-700 hover:text-orange-600" %></li>
+      <li><%= link_to "ホーム", home_path, class: "btn btn-ghost btn-sm #{current_page?(home_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
+      <li><%= link_to "カレンダー", calendar_path, class: "btn btn-ghost btn-sm #{current_page?(calendar_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
+      <li><%= link_to "献立相談", new_meal_search_path, class: "btn btn-ghost btn-sm #{current_page?(new_meal_search_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
+      <li><%= link_to "みんなのハレ", public_hare_entries_path, class: "btn btn-ghost btn-sm #{current_page?(public_hare_entries_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
+      <li><%= link_to "ハレ投稿", new_hare_entry_path, class: "btn btn-ghost btn-sm #{current_page?(new_hare_entry_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
+      <li><%= link_to "プロフィール", profile_path, class: "btn btn-ghost btn-sm #{current_page?(profile_path) ? 'text-orange-600 bg-orange-50' : 'text-gray-700 hover:text-orange-600'}" %></li>
     </ul>
   </div>
 


### PR DESCRIPTION
## 概要
現在どのページにいるか、ナビゲーションで視覚的に分かるようアクティブスタイルを追加。

## 関連 Issue
closes #169

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/views/shared/_header.html.erb` | 修正 | `current_page?` によるアクティブスタイル条件分岐を追加 |

## 実装のポイント
- `current_page?` ヘルパー（`ActionView::Helpers::UrlHelper`）でリクエストパスを判定
- アクティブ時: `text-orange-600 bg-orange-50`（薄いオレンジ背景 + 濃いオレンジ文字）
- 非アクティブ時: 従来通り `text-gray-700 hover:text-orange-600`
- モバイルのハンバーガーメニュー（6リンク）・デスクトップ横並びメニュー（6リンク）の両方に適用

## テスト計画
- [ ] 各ページにアクセスし、対応するナビアイテムがオレンジでハイライトされることを確認
- [ ] モバイル表示（ハンバーガーメニュー展開時）でも同様に確認
- [ ] 別ページのナビアイテムがアクティブにならないことを確認

## 残件・TODO
- なし