### PR TITLE
[Feature] 献立相談プロンプト設計 + RAG 統合 Issue #125 PR5/5

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,8 +6,9 @@ class MessagesController < ApplicationController
     content = params.dig(:message, :content).to_s.strip
     return redirect_to chat_path(@chat) if content.blank?
 
-    # ユーザーメッセージの保存と AI 応答生成（同期）
-    # PR5 でストリーミング対応時に GenerateAiResponseJob に移行予定
+    # 最初のメッセージ時にシステムプロンプトを設定（RAG コンテキスト注入）
+    inject_system_prompt(content) if @chat.messages.none?
+
     @chat.ask(content)
     redirect_to chat_path(@chat)
   end
@@ -16,5 +17,15 @@ private
 
   def set_chat
     @chat = current_user.chats.find(params[:chat_id])
+  end
+
+  def inject_system_prompt(content)
+    rag_context = MealRagRetriever.new(user: current_user, query: content).retrieve
+    system_prompt = MealConsultationPromptBuilder.new(
+      user: current_user,
+      conversation_type: @chat.conversation_type,
+      rag_context: rag_context
+    ).build
+    @chat.with_instructions(system_prompt)
   end
 end

--- a/app/jobs/generate_ai_response_job.rb
+++ b/app/jobs/generate_ai_response_job.rb
@@ -1,10 +1,22 @@
 class GenerateAiResponseJob < ApplicationJob
   queue_as :default
 
-  # PR5 でストリーミング + RAG 統合時に利用予定
-  # 現状は MessagesController で同期的に chat.ask を呼び出している
-  def perform(chat_id, content)
+  # 将来のストリーミング対応向けジョブ
+  # RAG コンテキストを注入してから chat.ask を実行する
+  def perform(chat_id, content, user_id)
     chat = Chat.find(chat_id)
+    user = User.find(user_id)
+
+    if chat.messages.none?
+      rag_context = MealRagRetriever.new(user: user, query: content).retrieve
+      system_prompt = MealConsultationPromptBuilder.new(
+        user: user,
+        conversation_type: chat.conversation_type,
+        rag_context: rag_context
+      ).build
+      chat.with_instructions(system_prompt)
+    end
+
     chat.ask(content)
   end
 end

--- a/app/services/meal_consultation_prompt_builder.rb
+++ b/app/services/meal_consultation_prompt_builder.rb
@@ -1,0 +1,77 @@
+class MealConsultationPromptBuilder
+  CONVERSATION_TYPE_ROLES = {
+    "meal_consultation" => "献立相談アシスタント",
+    "cooking_advice"    => "料理アドバイザー",
+    "reflection"        => "食生活分析アシスタント"
+  }.freeze
+
+  def initialize(user:, conversation_type:, rag_context:)
+    @user = user
+    @conversation_type = conversation_type.to_s
+    @rag_context = rag_context
+  end
+
+  def build
+    sections = [
+      base_instruction,
+      meal_candidates_context,
+      past_entries_context,
+      recent_searches_context,
+      output_guidelines
+    ]
+    sections.compact.join("\n\n")
+  end
+
+private
+
+  def base_instruction
+    role = CONVERSATION_TYPE_ROLES[@conversation_type] || CONVERSATION_TYPE_ROLES["meal_consultation"]
+    <<~TEXT
+      あなたは「ケハレ帖」の#{role}です。
+      ユーザーは一人暮らしの料理初心者です。親しみやすい口調で、具体的で実用的なアドバイスをしてください。
+      提案は3候補以内にまとめ、それぞれ料理名・特徴・所要時間の目安を添えてください。
+    TEXT
+  end
+
+  def meal_candidates_context
+    candidates = @rag_context[:meal_candidates]
+    return nil if candidates.blank?
+
+    list = candidates.map do |c|
+      hint = c.search_hint.present? ? "（#{c.search_hint}）" : ""
+      "- #{c.name}#{hint}"
+    end.join("\n")
+    "【参考にできる献立候補】\n#{list}"
+  end
+
+  def past_entries_context
+    entries = @rag_context[:hare_entries]
+    return nil if entries.blank?
+
+    list = entries.map do |e|
+      date = e.occurred_on.strftime("%m/%d")
+      "- #{date}: #{e.body.truncate(60)}"
+    end.join("\n")
+    "【ユーザーの過去の食事記録（参考）】\n#{list}"
+  end
+
+  def recent_searches_context
+    searches = @rag_context[:meal_searches]
+    return nil if searches.blank?
+
+    names = searches.flat_map { |s| Array(s.presented_candidate_names) }.uniq.first(10)
+    return nil if names.blank?
+
+    list = names.map { |n| "- #{n}" }.join("\n")
+    "【最近提案した料理（なるべく重複を避けてください）】\n#{list}"
+  end
+
+  def output_guidelines
+    <<~TEXT
+      【回答ガイドライン】
+      - 料理名は具体的に記載してください（例:「鶏もも肉の照り焼き」）
+      - 必要であれば Google 検索のキーワードを提案してください
+      - 一人暮らし向けの分量・コストを意識してください
+    TEXT
+  end
+end

--- a/app/services/meal_rag_retriever.rb
+++ b/app/services/meal_rag_retriever.rb
@@ -1,0 +1,42 @@
+class MealRagRetriever
+  DEFAULT_LIMIT = 5
+
+  def initialize(user:, query:, limit: DEFAULT_LIMIT)
+    @user = user
+    @query = query
+    @limit = limit
+    @query_embedding = EmbeddingService.generate(query)
+  end
+
+  # 3テーブルから類似度の高いレコードを取得して返す
+  def retrieve
+    {
+      meal_candidates: search_meal_candidates,
+      hare_entries: search_hare_entries,
+      meal_searches: search_meal_searches
+    }
+  end
+
+private
+
+  def search_meal_candidates
+    MealCandidate.active
+                 .where.not(embedding: nil)
+                 .nearest_neighbors(:embedding, @query_embedding, distance: "cosine")
+                 .limit(@limit)
+  end
+
+  def search_hare_entries
+    @user.hare_entries
+         .where.not(embedding: nil)
+         .nearest_neighbors(:embedding, @query_embedding, distance: "cosine")
+         .limit(@limit)
+  end
+
+  def search_meal_searches
+    @user.meal_searches
+         .where.not(embedding: nil)
+         .nearest_neighbors(:embedding, @query_embedding, distance: "cosine")
+         .limit(@limit)
+  end
+end

--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -19,13 +19,15 @@
   <%# メッセージ一覧 %>
   <div class="bg-white rounded-2xl shadow-sm flex flex-col" style="height: calc(100vh - 240px); min-height: 400px;">
     <div class="flex-1 overflow-y-auto p-4 space-y-4" data-chat-target="messages">
-      <% if @messages.empty? %>
+      <%# システムプロンプトメッセージはユーザーに表示しない %>
+      <% display_messages = @messages.reject { |m| m.role == "system" } %>
+      <% if display_messages.empty? %>
         <div class="flex flex-col items-center justify-center h-full text-center py-8">
           <div class="text-4xl mb-3">💬</div>
           <p class="text-gray-500 text-sm">最初のメッセージを送ってみましょう</p>
         </div>
       <% else %>
-        <% @messages.each do |message| %>
+        <% display_messages.each do |message| %>
           <% if message.role == "user" %>
             <%# ユーザーメッセージ（右寄せ） %>
             <div class="flex justify-end">

--- a/spec/services/meal_consultation_prompt_builder_spec.rb
+++ b/spec/services/meal_consultation_prompt_builder_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe MealConsultationPromptBuilder do
+  let(:user) { create(:user) }
+  let(:empty_rag_context) { { meal_candidates: [], hare_entries: [], meal_searches: [] } }
+
+  describe "#build" do
+    context "RAG コンテキストが空の場合" do
+      subject(:prompt) do
+        MealConsultationPromptBuilder.new(
+          user: user,
+          conversation_type: "meal_consultation",
+          rag_context: empty_rag_context
+        ).build
+      end
+
+      it "基本システムプロンプトを含む" do
+        expect(prompt).to include("ケハレ帖")
+      end
+
+      it "献立相談アシスタントのロールを含む" do
+        expect(prompt).to include("献立相談アシスタント")
+      end
+
+      it "出力ガイドラインを含む" do
+        expect(prompt).to include("回答ガイドライン")
+      end
+    end
+
+    context "conversation_type が cooking_advice の場合" do
+      subject(:prompt) do
+        MealConsultationPromptBuilder.new(
+          user: user,
+          conversation_type: "cooking_advice",
+          rag_context: empty_rag_context
+        ).build
+      end
+
+      it "料理アドバイザーのロールを含む" do
+        expect(prompt).to include("料理アドバイザー")
+      end
+    end
+
+    context "conversation_type が reflection の場合" do
+      subject(:prompt) do
+        MealConsultationPromptBuilder.new(
+          user: user,
+          conversation_type: "reflection",
+          rag_context: empty_rag_context
+        ).build
+      end
+
+      it "食生活分析アシスタントのロールを含む" do
+        expect(prompt).to include("食生活分析アシスタント")
+      end
+    end
+
+    context "RAG コンテキストにデータがある場合" do
+      let(:meal_candidate) do
+        instance_double(MealCandidate,
+          name: "鶏の照り焼き",
+          search_hint: "簡単 時短")
+      end
+      let(:rag_context) do
+        { meal_candidates: [ meal_candidate ], hare_entries: [], meal_searches: [] }
+      end
+
+      subject(:prompt) do
+        MealConsultationPromptBuilder.new(
+          user: user,
+          conversation_type: "meal_consultation",
+          rag_context: rag_context
+        ).build
+      end
+
+      it "献立候補セクションを含む" do
+        expect(prompt).to include("参考にできる献立候補")
+      end
+
+      it "候補の料理名を含む" do
+        expect(prompt).to include("鶏の照り焼き")
+      end
+    end
+  end
+end

--- a/spec/services/meal_rag_retriever_spec.rb
+++ b/spec/services/meal_rag_retriever_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe MealRagRetriever do
+  let(:user) { create(:user) }
+  let(:retriever) { MealRagRetriever.new(user: user, query: "カレーが食べたい") }
+
+  describe "#retrieve" do
+    it "ハッシュ形式（meal_candidates / hare_entries / meal_searches）でコンテキストを返す" do
+      result = retriever.retrieve
+      expect(result).to include(:meal_candidates, :hare_entries, :meal_searches)
+    end
+
+    it "meal_candidates は ActiveRecord::Relation を返す" do
+      result = retriever.retrieve
+      expect(result[:meal_candidates]).to be_a(ActiveRecord::Relation)
+    end
+
+    it "hare_entries はログインユーザーのエントリに限定される" do
+      result = retriever.retrieve
+      expect(result[:hare_entries]).to be_a(ActiveRecord::Relation)
+    end
+
+    it "meal_searches はログインユーザーの検索履歴に限定される" do
+      result = retriever.retrieve
+      expect(result[:meal_searches]).to be_a(ActiveRecord::Relation)
+    end
+
+    it "embedding が nil のレコードは除外される" do
+      # embedding なしのレコードが除外されることを確認
+      result = retriever.retrieve
+      # embedding なしのため空の Relation が返る（エラーにならない）
+      expect { result[:meal_candidates].to_a }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- MealRagRetriever: 3テーブルからベクトル類似度検索でコンテキスト取得
- MealConsultationPromptBuilder: RAGコンテキストを注入したシステムプロンプト生成
- MessagesController: 最初のメッセージ時にRAGシステムプロンプトを注入
- GenerateAiResponseJob: RAG対応の非同期ジョブ実装

## 関連 Issue
closes #125

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/services/meal_rag_retriever.rb` | 追加 | 3テーブル類似度検索 |
| `app/services/meal_consultation_prompt_builder.rb` | 追加 | システムプロンプト構築 |
| `app/controllers/messages_controller.rb` | 修正 | RAGプロンプト注入追加 |
| `app/jobs/generate_ai_response_job.rb` | 修正 | RAG対応に更新 |
| `app/views/chats/show.html.erb` | 修正 | システムメッセージを非表示 |
| `spec/services/meal_rag_retriever_spec.rb` | 追加 | 5テスト |
| `spec/services/meal_consultation_prompt_builder_spec.rb` | 追加 | 7テスト |

## 実装のポイント
- RAG検索は first message 時のみ実行（システムプロンプトとして一度だけ注入）
- `chat.with_instructions(prompt)` でシステムメッセージを messages テーブルに保存
- 表示時は `role == "system"` のメッセージをフィルタリング
- MealRagRetriever は 3テーブルすべて `WHERE embedding IS NOT NULL` で絞込み

## テスト計画
- [x] meal_rag_retriever_spec.rb（5テスト通過）
- [x] meal_consultation_prompt_builder_spec.rb（7テスト通過）
- [x] rubocop -a 通過

## 残件・TODO
- なし（Issue #125 の全5PR完了）