### PR TITLE
[Fix] embedding モデルを gemini-embedding-001 に修正（VertexAI エラー解消）

### DIFF
--- a/app/services/embedding_service.rb
+++ b/app/services/embedding_service.rb
@@ -1,5 +1,7 @@
 class EmbeddingService
-  EMBEDDING_MODEL = "text-embedding-004"
+  # gemini-embedding-001 は Gemini API 経由で利用可能なモデル（768次元）
+  # text-embedding-004 は ruby_llm のモデルレジストリに存在せず VertexAI にルートされるため使用不可
+  EMBEDDING_MODEL = "gemini-embedding-001"
 
   # テキストをベクトル（768次元）に変換する
   # @param text [String] 変換対象のテキスト

--- a/spec/services/embedding_service_spec.rb
+++ b/spec/services/embedding_service_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe EmbeddingService do
       expect(result.length).to eq(768)
     end
 
-    it "text-embedding-004 モデルを使用する" do
+    it "gemini-embedding-001 モデルを使用する" do
       expect(RubyLLM).to receive(:embed).with(
         "テストテキスト",
-        model: "text-embedding-004"
+        model: "gemini-embedding-001"
       ).and_return(
         instance_double(RubyLLM::Embedding, vectors: dummy_vector)
       )
@@ -28,7 +28,7 @@ RSpec.describe EmbeddingService do
     it "nil を渡しても空文字として処理する" do
       expect(RubyLLM).to receive(:embed).with(
         "",
-        model: "text-embedding-004"
+        model: "gemini-embedding-001"
       ).and_return(
         instance_double(RubyLLM::Embedding, vectors: dummy_vector)
       )


### PR DESCRIPTION
## 概要
- `text-embedding-004` が ruby_llm のモデルレジストリに存在せず VertexAI にルートされ `RubyLLM::ConfigurationError` が発生
- ruby_llm が Gemini API プロバイダーとして認識する `gemini-embedding-001` に変更

## エラー内容
```
RubyLLM::ConfigurationError in MealSearchesController#create
Missing configuration for VertexAI: vertexai_project_id, vertexai_location
```

## 原因
ruby_llm v1.12.1 のモデルレジストリに `text-embedding-004` が登録されていない。
未知のモデルを使用すると VertexAI へのフォールバックが発生し、VertexAI 設定が必要になる。

## 修正内容
- `EmbeddingService::EMBEDDING_MODEL` = `"text-embedding-004"` → `"gemini-embedding-001"`
- `gemini-embedding-001` は Gemini API (gemini プロバイダー) で利用可能（768次元、互換性あり）
- `spec/services/embedding_service_spec.rb` のモデル名を更新

## 変更ファイル
| ファイル | 変更 |
|---------|------|
| `app/services/embedding_service.rb` | EMBEDDING_MODEL を `gemini-embedding-001` に変更 |
| `spec/services/embedding_service_spec.rb` | モデル名テストを更新 |

## 関連 Issue
bugfix for #125