### PR TITLE
[Fix] EmbeddingService を Gemini REST API 直接呼び出しに変更し 768 次元を維持

### DIFF
--- a/app/services/embedding_service.rb
+++ b/app/services/embedding_service.rb
@@ -1,13 +1,21 @@
 class EmbeddingService
-  # gemini-embedding-001 は Gemini API 経由で利用可能なモデル（768次元）
-  # text-embedding-004 は ruby_llm のモデルレジストリに存在せず VertexAI にルートされるため使用不可
-  EMBEDDING_MODEL = "gemini-embedding-001"
+  # text-embedding-004: Gemini API が提供する 768 次元埋め込みモデル
+  # ruby_llm のモデルレジストリに未登録のため VertexAI にルーティングされる問題を回避し、
+  # Gemini REST API へ直接 HTTP リクエストを送信する
+  EMBEDDING_MODEL = "text-embedding-004"
+  GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 
   # テキストをベクトル（768次元）に変換する
   # @param text [String] 変換対象のテキスト
   # @return [Array<Float>] 768次元のベクトル
   def self.generate(text)
-    result = RubyLLM.embed(text.to_s, model: EMBEDDING_MODEL)
-    result.vectors
+    api_key = ENV.fetch("GEMINI_API_KEY")
+    uri = URI("#{GEMINI_API_BASE}/#{EMBEDDING_MODEL}:embedContent?key=#{api_key}")
+    body = {
+      model: "models/#{EMBEDDING_MODEL}",
+      content: { parts: [ { text: text.to_s } ] }
+    }.to_json
+    response = Net::HTTP.post(uri, body, "Content-Type" => "application/json")
+    JSON.parse(response.body).dig("embedding", "values")
   end
 end

--- a/db/migrate/20260227035141_change_embedding_dimension_to3072.rb
+++ b/db/migrate/20260227035141_change_embedding_dimension_to3072.rb
@@ -1,0 +1,20 @@
+class ChangeEmbeddingDimensionTo3072 < ActiveRecord::Migration[8.1]
+  # 前回の migration が途中で失敗し、meal_candidates が vector(3072)・インデックスなしの状態になった
+  # → 768 次元 + HNSW インデックスに復元する（hare_entries / meal_searches と整合させる）
+  def up
+    remove_column :meal_candidates, :embedding
+    add_column :meal_candidates, :embedding, :vector, limit: 768
+    add_index :meal_candidates, :embedding,
+      using: :hnsw,
+      opclass: { embedding: :vector_cosine_ops }
+  end
+
+  def down
+    remove_index :meal_candidates, :embedding
+    remove_column :meal_candidates, :embedding
+    add_column :meal_candidates, :embedding, :vector, limit: 768
+    add_index :meal_candidates, :embedding,
+      using: :hnsw,
+      opclass: { embedding: :vector_cosine_ops }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_27_025756) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_27_035141) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,12 +70,13 @@ RSpec.configure do |config|
     end
     DatabaseCleaner.start
 
-    # RubyLLM.embed のグローバルスタブ
-    # before_save コールバックが実際の Gemini API を呼ばないようにする
-    # EmbeddingService.generate はそのまま実行され、その内部の RubyLLM.embed のみ差し替える
-    # embedding_service_spec.rb 内では個別に expect(...).to receive で上書きするため問題なし
-    dummy_embedding = instance_double(RubyLLM::Embedding, vectors: Array.new(768, 0.1))
-    allow(RubyLLM).to receive(:embed).and_return(dummy_embedding)
+    # EmbeddingService.generate のグローバルスタブ
+    # before_save コールバックが実際の Gemini REST API を呼ばないようにする
+    # embedding_service_spec.rb は skip_embedding_stub: true メタデータで除外し、
+    # Net::HTTP レベルでスタブして実装そのものをテストする
+    next if example.metadata[:skip_embedding_stub]
+
+    allow(EmbeddingService).to receive(:generate).and_return(Array.new(768, 0.1))
   end
 
   config.after(:each) do

--- a/spec/services/embedding_service_spec.rb
+++ b/spec/services/embedding_service_spec.rb
@@ -1,37 +1,43 @@
 require "rails_helper"
 
-RSpec.describe EmbeddingService do
+# skip_embedding_stub: true → rails_helper のグローバルスタブを除外し、
+# Net::HTTP レベルでスタブして実装そのものをテストする
+RSpec.describe EmbeddingService, skip_embedding_stub: true do
   let(:dummy_vector) { Array.new(768, 0.1) }
+  let(:api_response_body) do
+    { "embedding" => { "values" => dummy_vector } }.to_json
+  end
+  let(:mock_http_response) do
+    instance_double(Net::HTTPResponse, body: api_response_body)
+  end
+
+  before do
+    allow(Net::HTTP).to receive(:post).and_return(mock_http_response)
+  end
 
   describe ".generate" do
     it "テキストを768次元のベクトルに変換する" do
-      allow(RubyLLM).to receive(:embed).and_return(
-        instance_double(RubyLLM::Embedding, vectors: dummy_vector)
-      )
-
       result = EmbeddingService.generate("疲れた日に簡単なもの")
       expect(result).to eq(dummy_vector)
       expect(result.length).to eq(768)
     end
 
-    it "gemini-embedding-001 モデルを使用する" do
-      expect(RubyLLM).to receive(:embed).with(
-        "テストテキスト",
-        model: "gemini-embedding-001"
-      ).and_return(
-        instance_double(RubyLLM::Embedding, vectors: dummy_vector)
-      )
+    it "text-embedding-004 モデルを使用する" do
+      expect(Net::HTTP).to receive(:post).with(
+        satisfy { |uri| uri.to_s.include?("text-embedding-004") },
+        anything,
+        anything
+      ).and_return(mock_http_response)
 
       EmbeddingService.generate("テストテキスト")
     end
 
     it "nil を渡しても空文字として処理する" do
-      expect(RubyLLM).to receive(:embed).with(
-        "",
-        model: "gemini-embedding-001"
-      ).and_return(
-        instance_double(RubyLLM::Embedding, vectors: dummy_vector)
-      )
+      expect(Net::HTTP).to receive(:post).with(
+        anything,
+        satisfy { |body| JSON.parse(body).dig("content", "parts", 0, "text") == "" },
+        anything
+      ).and_return(mock_http_response)
 
       EmbeddingService.generate(nil)
     end


### PR DESCRIPTION
## 概要
- `gemini-embedding-001` が 3072 次元を生成し `PG::DataException: expected 768 dimensions, not 3072` が発生
- HNSW インデックスの上限（2000 次元）も超えるため 3072 次元化は断念
- `text-embedding-004`（768 次元）を Gemini REST API に直接呼び出すことで解決

## 関連 Issue
Issue #125 バグ修正

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/services/embedding_service.rb` | 変更 | Net::HTTP で Gemini REST API を直接呼び出す方式に変更 |
| `spec/services/embedding_service_spec.rb` | 変更 | Net::HTTP スタブ方式に更新 |
| `spec/rails_helper.rb` | 変更 | グローバルスタブを EmbeddingService.generate レベルに変更 |
| `db/migrate/20260227035141_*.rb` | 変更 | 失敗した migration を meal_candidates 768 次元復元処理に修正 |
| `db/schema.rb` | 変更 | migration 適用後のスキーマを反映 |

## 実装のポイント
- `text-embedding-004` は ruby_llm のモデルレジストリに未登録 → VertexAI へルーティングされていた
- `gemini-embedding-001` は登録済みだが 3072 次元 → HNSW インデックス（上限 2000）に格納不可
- Gemini REST API を Net::HTTP で直接呼び出すことで ruby_llm の制約を回避
- テストでは `skip_embedding_stub: true` メタデータで個別スタブと global スタブを分離

## テスト計画
- [x] `embedding_service_spec.rb` 3 tests passing
- [x] `services/` 全スペック 71 examples, 0 failures