### PR TITLE
[Fix] チャット入力欄のテキスト色を修正

### DIFF
--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -61,7 +61,7 @@
         <%= f.text_area :content,
                         placeholder: "メッセージを入力... (Ctrl+Enter で送信)",
                         rows: 1,
-                        class: "flex-1 resize-none overflow-hidden border border-gray-200 rounded-xl px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-green-400 focus:border-transparent",
+                        class: "flex-1 resize-none overflow-hidden border border-gray-200 rounded-xl px-4 py-3 text-sm text-gray-800 placeholder-gray-400 bg-white focus:outline-none focus:ring-2 focus:ring-green-400 focus:border-transparent",
                         data: {
                           chat_target: "input",
                           action: "input->chat#resize keydown->chat#handleKeydown"


### PR DESCRIPTION
## 概要
- チャット入力欄に入力した文字が背景と同化して見えない問題を修正

## 問題
`text_area` に文字色クラスが未指定だったため、テキストが背景に溶け込んで視認できなかった

## 変更内容
`app/views/chats/show.html.erb` の入力欄に以下を追加：
- `text-gray-800` — 入力文字を濃いグレー（黒に近い色）で表示
- `placeholder-gray-400` — プレースホルダーを薄いグレーで表示
- `bg-white` — 背景を明示的に白に設定

## 関連
チャット入力 UI の視認性改善