### PR TITLE
[Feature] チャット開始時にウェルカムメッセージを表示

### DIFF
--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -22,9 +22,22 @@
       <%# システムプロンプトメッセージはユーザーに表示しない %>
       <% display_messages = @messages.reject { |m| m.role == "system" } %>
       <% if display_messages.empty? %>
-        <div class="flex flex-col items-center justify-center h-full text-center py-8">
-          <div class="text-4xl mb-3">💬</div>
-          <p class="text-gray-500 text-sm">最初のメッセージを送ってみましょう</p>
+        <%# チャットタイプに応じたウェルカムメッセージ %>
+        <div class="flex items-start gap-2">
+          <div class="w-8 h-8 rounded-full bg-gradient-to-br from-orange-400 to-yellow-300 flex items-center justify-center flex-shrink-0 mt-1">
+            <span class="text-sm">🤖</span>
+          </div>
+          <div class="max-w-xs md:max-w-sm bg-gray-100 rounded-2xl rounded-bl-sm px-4 py-3">
+            <% if @chat.cooking_advice? %>
+              <p class="text-sm text-gray-800">食材の保存方法・調理法・代替材料など、料理のことなら何でも聞いてください！</p>
+              <p class="text-xs text-gray-500 mt-2">例: 「鶏もものおすすめの保存方法は？」</p>
+            <% elsif @chat.meal_consultation? %>
+              <p class="text-sm text-gray-800">今日のごはん、一緒に考えましょう！</p>
+              <p class="text-xs text-gray-500 mt-2">「冷蔵庫に〇〇がある」「疲れてるから簡単なもの」など、気軽に教えてください。</p>
+            <% else %>
+              <p class="text-sm text-gray-800">最初のメッセージを送ってみましょう 💬</p>
+            <% end %>
+          </div>
         </div>
       <% else %>
         <% display_messages.each do |message| %>


### PR DESCRIPTION
## 概要

チャット画面を開いた直後（メッセージが空の状態）に、AIからのウェルカムメッセージを表示。
「このチャットで何を聞けばいいか」をユーザーに明確に伝え、正しい使い方に誘導する。

## 関連 Issue

refs #127

## 変更内容

### 変更前

```
💬
最初のメッセージを送ってみましょう
```

### 変更後

👨‍🍳 料理アドバイスを開いたとき:
```
🤖 食材の保存方法・調理法・代替材料など、料理のことなら何でも聞いてください！
   例: 「鶏もものおすすめの保存方法は？」
```

🍚 献立相談を開いたとき:
```
🤖 今日のごはん、一緒に考えましょう！
   「冷蔵庫に〇〇がある」「疲れてるから簡単なもの」など、気軽に教えてください。
```

## 実装のポイント

- DBへの保存なし、ビューのみで実現（`display_messages.empty?` の分岐に追加）
- 既存のAIメッセージと同じスタイル（アイコン・バブル）で統一感を出す

## テスト計画

- [x] チャットリクエストスペック（13件）通過
- [x] システムスペック（7件）通過