### PR TITLE
[Feature] AI提案からハレ投稿へのワンタップ導線を追加

### DIFF
--- a/app/controllers/hare_entries_controller.rb
+++ b/app/controllers/hare_entries_controller.rb
@@ -12,7 +12,7 @@ class HareEntriesController < ApplicationController
     end
 
     def new
-      @hare_entry = HareEntry.new(occurred_on: Date.today)
+      @hare_entry = HareEntry.new(occurred_on: Date.today, body: params[:body])
       @hare_tags = HareTag.active.sorted
     end
 

--- a/app/views/meal_searches/index.html.erb
+++ b/app/views/meal_searches/index.html.erb
@@ -22,11 +22,16 @@
             <p class="text-sm text-gray-600 mb-4">
               ジャンル: <span class="font-semibold"><%= candidate.genre.label %></span>
             </p>
-            <%= link_to "Google で検索",
-                        GoogleSearchQueryBuilder.new(candidate.name).url,
-                        target: "_blank",
-                        rel: "noopener noreferrer",
-                        class: "inline-block bg-white text-green-700 px-4 py-2 rounded-full text-sm font-semibold hover:bg-green-50 transition-colors shadow-sm" %>
+            <div class="flex flex-col gap-2 mt-2">
+              <%= link_to "Google で検索",
+                          GoogleSearchQueryBuilder.new(candidate.name).url,
+                          target: "_blank",
+                          rel: "noopener noreferrer",
+                          class: "inline-block bg-white text-green-700 px-4 py-2 rounded-full text-sm font-semibold hover:bg-green-50 transition-colors shadow-sm text-center" %>
+              <%= link_to "これにした！記録する",
+                          new_hare_entry_path(body: candidate.name),
+                          class: "inline-block bg-orange-400 text-white px-4 py-2 rounded-full text-sm font-semibold hover:bg-orange-500 transition-colors shadow-sm text-center" %>
+            </div>
           </div>
         <% end %>
       </div>

--- a/spec/requests/hare_entries_spec.rb
+++ b/spec/requests/hare_entries_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe "HareEntries", type: :request do
         get new_hare_entry_path
         expect(response.body).to include('href="/"')
       end
+
+      context 'bodyパラメータが渡された場合' do
+        it 'bodyの初期値がフォームに表示される' do
+          get new_hare_entry_path(body: 'カレーライス')
+          expect(response.body).to include('カレーライス')
+        end
+      end
+
+      context 'bodyパラメータがない場合' do
+        it 'bodyは空で表示される' do
+          get new_hare_entry_path
+          expect(response).to have_http_status(:success)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## 概要
AI が提案した献立候補から、ワンタップでハレ投稿フォームへ遷移できる導線を追加した。

## 関連 Issue
closes #172

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/views/meal_searches/index.html.erb` | 変更 | 候補カードに「これにした！記録する」ボタンを追加 |
| `app/controllers/hare_entries_controller.rb` | 変更 | `new` アクションで `params[:body]` を初期値として設定 |
| `spec/requests/hare_entries_spec.rb` | 変更 | `body` パラメータ受け渡しのテストを追加 |

## 実装のポイント
- `new_hare_entry_path(body: candidate.name)` でメニュー名をクエリパラメータとして渡す
- コントローラーで `HareEntry.new(body: params[:body])` として初期値を設定
- `params[:body]` が `nil` の場合は空フォームが表示される（通常のアクセスと同じ動作）
- ERB のエスケープ処理により XSS の心配なし

## テスト計画
- [x] `body` パラメータ渡し時にフォームへ初期値が表示される
- [x] `body` パラメータなし時は正常にアクセスできる
- [x] 既存テスト 89件 全パス

## 残件・TODO
- なし