### PR TITLE
[Feature] AIレート制限エラーをユーザーフレンドリーに表示

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,6 +11,8 @@ class MessagesController < ApplicationController
 
     @chat.ask(content)
     redirect_to chat_path(@chat)
+  rescue RubyLLM::RateLimitError
+    redirect_to chat_path(@chat), alert: "AIが混み合っています。少し時間をおいてから再度お試しください。"
   end
 
 private

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Messages", type: :request do
+  let(:user) { create(:user) }
+  let!(:chat) { create(:chat, user: user) }
+
+  before { sign_in user }
+
+  describe "POST /chats/:chat_id/messages" do
+    context "AIがレート制限エラーを返した場合" do
+      before do
+        allow_any_instance_of(Chat).to receive(:ask).and_raise(RubyLLM::RateLimitError)
+      end
+
+      it "エラーページではなくチャット画面にリダイレクトする" do
+        post chat_messages_path(chat), params: { message: { content: "鶏肉の保存方法は？" } }
+        expect(response).to redirect_to(chat_path(chat))
+      end
+
+      it "ユーザーに分かりやすいFlashメッセージを表示する" do
+        post chat_messages_path(chat), params: { message: { content: "鶏肉の保存方法は？" } }
+        expect(flash[:alert]).to include("AIが混み合っています")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- Gemini API のレート制限超過時に500エラーページが表示されていた問題を修正
- `RubyLLM::RateLimitError` を rescue してチャット画面にリダイレクト

## 関連 Issue
closes #222

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/controllers/messages_controller.rb` | 変更 | RateLimitError の rescue 追加 |
| `spec/requests/messages_spec.rb` | 追加 | エラーハンドリングのリクエストスペック |

## 実装のポイント
- `create` アクション内で `rescue RubyLLM::RateLimitError` を追加
- エラー時は `chat_path(@chat)` にリダイレクトしてチャット画面を維持
- `alert:` で「AIが混み合っています。少し時間をおいてから再度お試しください。」を表示

## テスト計画
- [x] レート制限エラー時にチャット画面へリダイレクトされることを確認
- [x] Flash メッセージが表示されることを確認
- [x] RuboCop 違反なし