### PR TITLE
[Feature] AIチャットのローディング表示（Turbo Streams + 非同期化）

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ApplicationCable
+  # WebSocket 接続の認証を管理する
+  # Devise の Warden セッションを使って current_user を識別する
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+
+    def find_verified_user
+      verified_user = env["warden"].user
+      reject_unauthorized_connection unless verified_user
+      verified_user
+    end
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,10 +9,14 @@ class MessagesController < ApplicationController
     # 最初のメッセージ時にシステムプロンプトを設定（RAG コンテキスト注入）
     inject_system_prompt(content) if @chat.messages.none?
 
-    @chat.ask(content)
-    redirect_to chat_path(@chat)
-  rescue RubyLLM::RateLimitError
-    redirect_to chat_path(@chat), alert: "AIが混み合っています。少し時間をおいてから再度お試しください。"
+    # ユーザーメッセージを即時保存し、AI 応答生成をジョブにキュー投入
+    @message = @chat.create_user_message(content)
+    GenerateAiResponseJob.perform_later(@chat.id, current_user.id)
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to chat_path(@chat) }
+    end
   end
 
 private

--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -1,15 +1,46 @@
 import { Controller } from "@hotwired/stimulus"
 
 // チャット UI の制御
-// - メッセージ一覧の末尾へ自動スクロール
-// - 送信中の二重送信防止
+// - メッセージ一覧の末尾へ自動スクロール（Turbo Stream 更新時も含む）
+// - 送信中の二重送信防止とフォーム状態管理
 // - テキストエリアの自動リサイズ
+// - タイピングインジケーター消失時のフォーム再有効化
 export default class extends Controller {
   static targets = ["messages", "input", "submit"]
 
   connect() {
     this.scrollToBottom()
     this.inputTarget.focus()
+    this.observeMessages()
+  }
+
+  disconnect() {
+    if (this.observer) {
+      this.observer.disconnect()
+    }
+  }
+
+  // MutationObserver でメッセージ一覧の変化を監視する
+  // - 新しいメッセージ追加時に自動スクロール
+  // - タイピングインジケーター消失時にフォームを再有効化
+  observeMessages() {
+    if (!this.hasMessagesTarget) return
+
+    this.observer = new MutationObserver(() => {
+      this.scrollToBottom()
+
+      // タイピングインジケーターが消えたらフォームを再有効化
+      const typingIndicator = document.getElementById("typing_indicator")
+      if (!typingIndicator && this.hasSubmitTarget) {
+        this.submitTarget.disabled = false
+        this.submitTarget.textContent = "送信"
+        if (this.hasInputTarget) {
+          this.inputTarget.focus()
+        }
+      }
+    })
+
+    this.observer.observe(this.messagesTarget, { childList: true, subtree: true })
   }
 
   // メッセージ一覧の末尾へスクロール

--- a/app/jobs/generate_ai_response_job.rb
+++ b/app/jobs/generate_ai_response_job.rb
@@ -1,32 +1,53 @@
 class GenerateAiResponseJob < ApplicationJob
   queue_as :default
 
-  # 将来のストリーミング対応向けジョブ
-  # RAG コンテキストを注入してから chat.ask を実行する
-  def perform(chat_id, content, user_id)
+  # AI 応答を非同期で生成し、Turbo Streams でリアルタイム配信する
+  # システムプロンプトとユーザーメッセージはコントローラーで保存済み
+  def perform(chat_id, _user_id)
     chat = Chat.find(chat_id)
-    user = User.find(user_id)
 
-    if chat.messages.none?
-      system_prompt = build_system_prompt(chat, user, content)
-      chat.with_instructions(system_prompt)
-    end
+    # AI 応答を生成（コントローラーで保存したメッセージを元に complete を呼び出す）
+    chat.complete
 
-    chat.ask(content)
+    # 生成された AI メッセージを取得
+    ai_message = chat.messages.order(:id).last
+
+    # タイピングインジケーターを AI メッセージで置換してブロードキャスト
+    Turbo::StreamsChannel.broadcast_replace_to(
+      chat,
+      target: "typing_indicator",
+      partial: "messages/assistant_message",
+      locals: { message: ai_message, chat: chat }
+    )
+  rescue RubyLLM::RateLimitError
+    # レート制限エラー: タイピングインジケーターをエラーメッセージで置換
+    Turbo::StreamsChannel.broadcast_replace_to(
+      chat,
+      target: "typing_indicator",
+      html: error_html("AIが混み合っています。少し時間をおいてから再度お試しください。")
+    )
+  rescue StandardError
+    # その他のエラー
+    Turbo::StreamsChannel.broadcast_replace_to(
+      chat,
+      target: "typing_indicator",
+      html: error_html("エラーが発生しました。ページを再読み込みしてお試しください。")
+    )
+    raise
   end
 
 private
 
-  def build_system_prompt(chat, user, content)
-    if chat.cooking_advice?
-      CookingAdvicePromptBuilder.new(user: user).build
-    else
-      rag_context = MealRagRetriever.new(user: user, query: content).retrieve
-      MealConsultationPromptBuilder.new(
-        user: user,
-        conversation_type: chat.conversation_type,
-        rag_context: rag_context
-      ).build
-    end
+  def error_html(message)
+    <<~HTML
+      <div id="typing_indicator" class="flex items-start gap-2">
+        <div class="w-8 h-8 rounded-full bg-red-100 flex items-center justify-center flex-shrink-0 mt-1">
+          <span class="text-sm">⚠️</span>
+        </div>
+        <div class="bg-red-50 border border-red-200 rounded-2xl rounded-bl-sm px-4 py-3">
+          <p class="text-sm text-red-600">#{message}</p>
+        </div>
+      </div>
+    HTML
   end
 end

--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -6,6 +6,9 @@
   }
 %>
 
+<%# リアルタイム更新のための ActionCable 購読を設定 %>
+<%= turbo_stream_from @chat %>
+
 <main class="max-w-2xl mx-auto p-4 md:p-8" data-controller="chat">
   <%# ヘッダー %>
   <div class="flex items-center justify-between mb-4">
@@ -18,7 +21,7 @@
 
   <%# メッセージ一覧 %>
   <div class="bg-white rounded-2xl shadow-sm flex flex-col" style="height: calc(100vh - 240px); min-height: 400px;">
-    <div class="flex-1 overflow-y-auto p-4 space-y-4" data-chat-target="messages">
+    <div id="messages" class="flex-1 overflow-y-auto p-4 space-y-4" data-chat-target="messages">
       <%# システムプロンプトメッセージはユーザーに表示しない %>
       <% display_messages = @messages.reject { |m| m.role == "system" } %>
       <% if display_messages.empty? %>
@@ -42,39 +45,9 @@
       <% else %>
         <% display_messages.each do |message| %>
           <% if message.role == "user" %>
-            <%# ユーザーメッセージ（右寄せ） %>
-            <div class="flex justify-end">
-              <div class="max-w-xs md:max-w-sm bg-green-500 text-white rounded-2xl rounded-br-sm px-4 py-3">
-                <p class="text-sm whitespace-pre-wrap"><%= message.content %></p>
-                <p class="text-xs text-green-100 mt-1 text-right"><%= message.created_at.strftime("%H:%M") %></p>
-              </div>
-            </div>
+            <%= render "messages/user_message", message: message %>
           <% elsif message.role == "assistant" %>
-            <%# AI メッセージ（左寄せ） %>
-            <div class="flex items-start gap-2">
-              <div class="w-8 h-8 rounded-full bg-gradient-to-br from-orange-400 to-yellow-300 flex items-center justify-center flex-shrink-0 mt-1">
-                <span class="text-sm">🤖</span>
-              </div>
-              <div class="max-w-xs md:max-w-sm">
-                <div class="bg-gray-100 rounded-2xl rounded-bl-sm px-4 py-3">
-                  <p class="text-sm text-gray-800 whitespace-pre-wrap"><%= message.content %></p>
-                  <p class="text-xs text-gray-400 mt-1"><%= message.created_at.strftime("%H:%M") %></p>
-                </div>
-                <% if @chat.meal_consultation? %>
-                  <% dish_names = message.extract_dish_names %>
-                  <% if dish_names.any? %>
-                    <div class="mt-2 flex flex-col gap-1">
-                      <% dish_names.each do |dish_name| %>
-                        <%= link_to new_hare_entry_path(body: dish_name),
-                                    class: "inline-block text-xs text-green-700 hover:text-green-900 border border-green-400 rounded-lg px-3 py-1.5 hover:bg-green-50 transition-colors" do %>
-                          ✍️ <%= dish_name %>
-                        <% end %>
-                      <% end %>
-                    </div>
-                  <% end %>
-                <% end %>
-              </div>
-            </div>
+            <%= render "messages/assistant_message", message: message, chat: @chat %>
           <% end %>
         <% end %>
       <% end %>
@@ -87,6 +60,7 @@
                     data: { action: "submit->chat#submit" },
                     class: "flex items-end gap-2" do |f| %>
         <%= f.text_area :content,
+                        id: "message_input",
                         placeholder: "メッセージを入力... (Ctrl+Enter で送信)",
                         rows: 1,
                         class: "flex-1 resize-none overflow-hidden border border-gray-200 rounded-xl px-4 py-3 text-sm text-gray-800 placeholder-gray-400 bg-white focus:outline-none focus:ring-2 focus:ring-green-400 focus:border-transparent",
@@ -95,6 +69,7 @@
                           action: "input->chat#resize keydown->chat#handleKeydown"
                         } %>
         <%= f.submit "送信",
+                     id: "chat_submit_btn",
                      class: "bg-green-500 hover:bg-green-600 text-white font-semibold px-4 py-3 rounded-xl text-sm transition-colors flex-shrink-0 disabled:opacity-50 cursor-pointer",
                      data: { chat_target: "submit" } %>
       <% end %>

--- a/app/views/messages/_assistant_message.html.erb
+++ b/app/views/messages/_assistant_message.html.erb
@@ -1,0 +1,24 @@
+<div id="<%= dom_id(message) %>" class="flex items-start gap-2">
+  <div class="w-8 h-8 rounded-full bg-gradient-to-br from-orange-400 to-yellow-300 flex items-center justify-center flex-shrink-0 mt-1">
+    <span class="text-sm">🤖</span>
+  </div>
+  <div class="max-w-xs md:max-w-sm">
+    <div class="bg-gray-100 rounded-2xl rounded-bl-sm px-4 py-3">
+      <p class="text-sm text-gray-800 whitespace-pre-wrap"><%= message.content %></p>
+      <p class="text-xs text-gray-400 mt-1"><%= message.created_at.strftime("%H:%M") %></p>
+    </div>
+    <% if chat.meal_consultation? %>
+      <% dish_names = message.extract_dish_names %>
+      <% if dish_names.any? %>
+        <div class="mt-2 flex flex-col gap-1">
+          <% dish_names.each do |dish_name| %>
+            <%= link_to new_hare_entry_path(body: dish_name),
+                        class: "inline-block text-xs text-green-700 hover:text-green-900 border border-green-400 rounded-lg px-3 py-1.5 hover:bg-green-50 transition-colors" do %>
+              ✍️ <%= dish_name %>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/messages/_typing_indicator.html.erb
+++ b/app/views/messages/_typing_indicator.html.erb
@@ -1,0 +1,9 @@
+<%# AI が応答を生成中のタイピングインジケーター %>
+<div id="typing_indicator" class="flex items-start gap-2">
+  <div class="w-8 h-8 rounded-full bg-gradient-to-br from-orange-400 to-yellow-300 flex items-center justify-center flex-shrink-0 mt-1">
+    <span class="text-sm">🤖</span>
+  </div>
+  <div class="bg-gray-100 rounded-2xl rounded-bl-sm px-4 py-3">
+    <span class="loading loading-dots loading-sm text-gray-400"></span>
+  </div>
+</div>

--- a/app/views/messages/_user_message.html.erb
+++ b/app/views/messages/_user_message.html.erb
@@ -1,0 +1,6 @@
+<div id="<%= dom_id(message) %>" class="flex justify-end">
+  <div class="max-w-xs md:max-w-sm bg-green-500 text-white rounded-2xl rounded-br-sm px-4 py-3">
+    <p class="text-sm whitespace-pre-wrap"><%= message.content %></p>
+    <p class="text-xs text-green-100 mt-1 text-right"><%= message.created_at.strftime("%H:%M") %></p>
+  </div>
+</div>

--- a/app/views/messages/create.turbo_stream.erb
+++ b/app/views/messages/create.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%# ユーザーメッセージをメッセージ一覧の末尾に追加 %>
+<%= turbo_stream.append "messages", partial: "messages/user_message", locals: { message: @message } %>
+
+<%# AI のタイピングインジケーターを追加 %>
+<%= turbo_stream.append "messages", partial: "messages/typing_indicator" %>
+
+<%# テキストエリアの入力内容をクリア %>
+<%= turbo_stream.update "message_input", "" %>

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -7,19 +7,36 @@ RSpec.describe "Messages", type: :request do
   before { sign_in user }
 
   describe "POST /chats/:chat_id/messages" do
-    context "AIがレート制限エラーを返した場合" do
+    context "正常なメッセージ送信" do
       before do
-        allow_any_instance_of(Chat).to receive(:ask).and_raise(RubyLLM::RateLimitError)
+        # システムプロンプト生成をスタブ（外部 AI 呼び出しをスキップ）
+        allow_any_instance_of(MessagesController).to receive(:inject_system_prompt)
+        # 非同期ジョブの実行をスタブ（実際のキュー投入をスキップ）
+        allow(GenerateAiResponseJob).to receive(:perform_later)
       end
 
-      it "エラーページではなくチャット画面にリダイレクトする" do
+      it "Turbo Stream でレスポンスを返す" do
+        post chat_messages_path(chat), params: { message: { content: "鶏肉の保存方法は？" } },
+                                       headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      end
+
+      it "GenerateAiResponseJob をキューに投入する" do
+        expect(GenerateAiResponseJob).to receive(:perform_later).with(chat.id, user.id)
         post chat_messages_path(chat), params: { message: { content: "鶏肉の保存方法は？" } }
+      end
+
+      it "ユーザーメッセージをデータベースに保存する" do
+        expect {
+          post chat_messages_path(chat), params: { message: { content: "鶏肉の保存方法は？" } }
+        }.to change { chat.messages.where(role: "user").count }.by(1)
+      end
+    end
+
+    context "空のメッセージを送信した場合" do
+      it "チャット画面にリダイレクトする" do
+        post chat_messages_path(chat), params: { message: { content: "" } }
         expect(response).to redirect_to(chat_path(chat))
-      end
-
-      it "ユーザーに分かりやすいFlashメッセージを表示する" do
-        post chat_messages_path(chat), params: { message: { content: "鶏肉の保存方法は？" } }
-        expect(flash[:alert]).to include("AIが混み合っています")
       end
     end
   end


### PR DESCRIPTION
## 概要

AIチャットの通信方式を同期→非同期に変更し、ユーザー体験を大幅改善する。

- メッセージ送信後、ユーザーの発言が即時表示される
- AI応答生成中はタイピングインジケーター（ローディングドット）が表示される
- AI応答が届くとタイピングインジケーターがリアルタイムで置換される
- フォームはAI応答完了後に自動で再有効化される

## 関連 Issue

closes #224

## 変更ファイル一覧

| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/channels/application_cable/connection.rb` | 追加 | Devise認証でWebSocket接続を保護 |
| `app/channels/application_cable/channel.rb` | 追加 | ActionCable ベースチャンネル |
| `app/views/messages/_user_message.html.erb` | 追加 | ユーザーメッセージのパーシャル |
| `app/views/messages/_assistant_message.html.erb` | 追加 | AIメッセージのパーシャル |
| `app/views/messages/_typing_indicator.html.erb` | 追加 | AI応答生成中のローディング表示 |
| `app/views/messages/create.turbo_stream.erb` | 追加 | Turbo Streamレスポンステンプレート |
| `app/views/chats/show.html.erb` | 変更 | `turbo_stream_from`追加・パーシャル化・ID付与 |
| `app/controllers/messages_controller.rb` | 変更 | `ask()`→`create_user_message()`+`perform_later`に分割 |
| `app/jobs/generate_ai_response_job.rb` | 変更 | `complete()`+`broadcast_replace_to`でリアルタイム配信 |
| `app/javascript/controllers/chat_controller.js` | 変更 | MutationObserverで自動スクロール・フォーム再有効化 |
| `spec/requests/messages_spec.rb` | 変更 | 非同期対応のテストに更新 |

## 実装のポイント

### アーキテクチャ変更（Before/After）

**Before（同期）:**

フォーム送信 → Controller: chat.ask(content) → AI API呼び出し（5-15秒待機）→ redirect

**After（非同期）:**

フォーム送信 → Controller: create_user_message() + perform_later → Turbo Stream即時応答
                    ↓
       GenerateAiResponseJob: chat.complete() → broadcast_replace_to

### RubyLLM の `create_user_message` + `complete` 分割
- `ask()` = `create_user_message()` + `complete()` の組み合わせ
- `create_user_message()` だけ呼ぶことでDBに即時保存、AI呼び出しなし
- バックグラウンドジョブで `complete()` を呼び、既存メッセージを元にAI応答を生成

### Stimulus MutationObserver
- メッセージコンテナを監視し、DOM変化時に自動スクロール
- `#typing_indicator` 要素が消えた（AI応答で置換された）タイミングでフォームを再有効化

## テスト計画

- [x] RSpec request spec: Turbo Streamレスポンス確認
- [x] RSpec request spec: ジョブキュー投入確認
- [x] RSpec request spec: ユーザーメッセージDB保存確認
- [x] RSpec request spec: 空メッセージのリダイレクト確認

## 残件・TODO

- なし