### PR TITLE
[Feature] 絵文字をSVGアイコン（Lucide Icons）に置き換え

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,9 @@ gem "image_processing", "~> 1.2"
 gem "active_storage_validations"
 gem "cloudinary"  # 画像ストレージ・CDN（全環境で使用）
 
+# SVG アイコンライブラリ Lucide Icons [https://github.com/kgiszczak/lucide-rails]
+gem "lucide-rails"
+
 # AI / LLM 連携 [https://github.com/crmne/ruby_llm]
 gem "ruby_llm"
 # pgvector を ActiveRecord で扱う（ベクトル類似検索）[https://github.com/ankane/neighbor]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,8 @@ GEM
     loofah (2.25.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    lucide-rails (0.7.3)
+      railties (>= 4.1.0)
     mail (2.9.0)
       logger
       mini_mime (>= 0.1.1)
@@ -551,6 +553,7 @@ DEPENDENCIES
   jbuilder
   kamal
   kaminari
+  lucide-rails
   neighbor
   parallel_tests
   pg (~> 1.1)
@@ -664,6 +667,7 @@ CHECKSUMS
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.0) sha256=df5ed7ac3bac6a4ec802df3877ee5cc86d027299f8952e6243b3dac446b060e6
+  lucide-rails (0.7.3) sha256=024d03f1158a72e99bd46fba7b6ec1bbb22f2eb64c5b59af82427974a093da49
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  # Lucide SVG アイコンを描画するラッパーヘルパー
+  # @param name [String] Lucide アイコン名（例: "sparkles", "bot"）
+  # @param css_class [String] Tailwind CSS クラス（デフォルト: インラインテキスト用サイズ）
+  # @param options [Hash] その他の HTML 属性（aria-label 等）
+  def app_icon(name, css_class: "w-5 h-5 inline-block", **options)
+    lucide_icon(name, class: css_class, **options)
+  end
 end

--- a/app/views/calendar/index.html.erb
+++ b/app/views/calendar/index.html.erb
@@ -2,7 +2,7 @@
   <%# ページヘッダー %>
   <div class="mb-8">
     <div class="flex items-center gap-3 mb-2">
-      <span class="text-4xl">📅</span>
+      <%= app_icon("calendar", css_class: "w-10 h-10 text-orange-400") %>
       <h1 class="text-2xl md:text-3xl font-bold text-gray-800">ハレのカレンダー</h1>
     </div>
     <p class="text-gray-600">あなたのハレを振り返りましょう</p>

--- a/app/views/calendar/show.html.erb
+++ b/app/views/calendar/show.html.erb
@@ -2,7 +2,7 @@
   <%# ページヘッダー %>
   <div class="mb-8">
     <div class="flex items-center gap-2 md:gap-3 mb-4">
-      <span class="text-2xl md:text-4xl">📅</span>
+      <%= app_icon("calendar", css_class: "w-6 h-6 md:w-10 md:h-10 text-orange-400") %>
       <h1 class="text-xl md:text-3xl font-bold text-gray-800">
         <%= @date.strftime("%Y年%-m月%-d日") %> のハレ投稿
       </h1>
@@ -18,7 +18,7 @@
   <%# ハレ投稿一覧 %>
   <% if @hare_entries.empty? %>
     <div class="text-center py-20 bg-white rounded-2xl shadow-sm">
-      <div class="text-6xl mb-4">✨</div>
+      <div class="flex justify-center mb-4"><%= app_icon("sparkles", css_class: "w-16 h-16 text-yellow-400") %></div>
       <p class="text-gray-600 text-lg mb-2">この日はまだハレがありません</p>
       <p class="text-sm text-gray-500">小さなハレを見つけたら、記録してみましょう</p>
     </div>
@@ -42,7 +42,7 @@
           <%# ポイントがあれば表示 %>
           <% if entry.awarded_points&.positive? %>
             <div class="flex items-center gap-1 text-orange-600">
-              <span class="text-lg">✨</span>
+              <%= app_icon("sparkles", css_class: "w-4 h-4 text-yellow-400") %>
               <p class="text-sm font-semibold">+<%= entry.awarded_points %> ポイント</p>
             </div>
           <% end %>

--- a/app/views/chats/new.html.erb
+++ b/app/views/chats/new.html.erb
@@ -2,7 +2,7 @@
   <div class="flex items-center justify-between mb-6">
     <div>
       <h1 class="text-2xl font-bold text-gray-800 mb-1">AI 献立相談</h1>
-      <p class="text-gray-600 text-sm">何でもお気軽に相談してください ✨</p>
+      <p class="text-gray-600 text-sm flex items-center gap-1">何でもお気軽に相談してください <%= app_icon("sparkles", css_class: "w-4 h-4 text-yellow-400") %></p>
     </div>
     <%= link_to "ホーム", home_path, class: "text-gray-500 hover:text-gray-700 text-sm font-medium" %>
   </div>
@@ -15,14 +15,14 @@
           <label class="flex items-center gap-3 cursor-pointer p-4 border-2 border-gray-200 rounded-xl hover:border-green-300 transition-colors has-[:checked]:border-green-400 has-[:checked]:bg-green-50">
             <%= f.radio_button :conversation_type, "meal_consultation", class: "text-green-500 w-4 h-4" %>
             <div>
-              <div class="font-semibold text-gray-800">🍚 献立相談</div>
+              <div class="font-semibold text-gray-800 flex items-center gap-1.5"><%= app_icon("utensils", css_class: "w-5 h-5 text-green-600") %> 献立相談</div>
               <div class="text-sm text-gray-500">今日のごはんを一緒に決めます</div>
             </div>
           </label>
           <label class="flex items-center gap-3 cursor-pointer p-4 border-2 border-gray-200 rounded-xl hover:border-orange-300 transition-colors has-[:checked]:border-orange-400 has-[:checked]:bg-orange-50">
             <%= f.radio_button :conversation_type, "cooking_advice", class: "text-orange-500 w-4 h-4" %>
             <div>
-              <div class="font-semibold text-gray-800">👨‍🍳 料理アドバイス</div>
+              <div class="font-semibold text-gray-800 flex items-center gap-1.5"><%= app_icon("chef-hat", css_class: "w-5 h-5 text-orange-500") %> 料理アドバイス</div>
               <div class="text-sm text-gray-500">レシピや調理のコツを教えます</div>
             </div>
           </label>

--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -1,8 +1,8 @@
 <%
   type_labels = {
-    "meal_consultation" => "🍚 献立相談",
-    "cooking_advice"    => "👨‍🍳 料理アドバイス",
-    "reflection"        => "📖 振り返り分析"
+    "meal_consultation" => "献立相談",
+    "cooking_advice"    => "料理アドバイス",
+    "reflection"        => "振り返り分析"
   }
 %>
 
@@ -28,7 +28,7 @@
         <%# チャットタイプに応じたウェルカムメッセージ %>
         <div class="flex items-start gap-2">
           <div class="w-8 h-8 rounded-full bg-gradient-to-br from-orange-400 to-yellow-300 flex items-center justify-center flex-shrink-0 mt-1">
-            <span class="text-sm">🤖</span>
+            <%= app_icon("bot", css_class: "w-4 h-4 text-white") %>
           </div>
           <div class="max-w-xs md:max-w-sm bg-gray-100 rounded-2xl rounded-bl-sm px-4 py-3">
             <% if @chat.cooking_advice? %>
@@ -38,7 +38,7 @@
               <p class="text-sm text-gray-800">今日のごはん、一緒に考えましょう！</p>
               <p class="text-xs text-gray-500 mt-2">「冷蔵庫に〇〇がある」「疲れてるから簡単なもの」など、気軽に教えてください。</p>
             <% else %>
-              <p class="text-sm text-gray-800">最初のメッセージを送ってみましょう 💬</p>
+              <p class="text-sm text-gray-800 flex items-center gap-1">最初のメッセージを送ってみましょう <%= app_icon("message-circle", css_class: "w-4 h-4 text-gray-500") %></p>
             <% end %>
           </div>
         </div>

--- a/app/views/hare_entries/edit.html.erb
+++ b/app/views/hare_entries/edit.html.erb
@@ -7,7 +7,7 @@
   <%# ページヘッダー %>
   <div class="mb-6">
     <h1 class="text-3xl font-bold text-gray-800 mb-2">ハレの記録を編集する</h1>
-    <p class="text-gray-600">記録を更新しましょう 📝</p>
+    <p class="text-gray-600 flex items-center gap-1">記録を更新しましょう <%= app_icon("notebook-pen", css_class: "w-4 h-4 text-gray-500") %></p>
   </div>
 
   <%# フォームカード %>

--- a/app/views/hare_entries/index.html.erb
+++ b/app/views/hare_entries/index.html.erb
@@ -19,7 +19,7 @@
           </div>
         </div>
       </div>
-      <div class="text-3xl md:text-5xl mt-3 sm:mt-0">🌸</div>
+      <div class="mt-3 sm:mt-0"><%= app_icon("flower-2", css_class: "w-8 h-8 md:w-12 md:h-12 text-pink-400") %></div>
     </div>
   </div>
 
@@ -54,7 +54,7 @@
   <% else %>
     <%# 空状態 %>
     <div class="text-center py-20 bg-white rounded-2xl shadow-sm">
-      <div class="text-6xl mb-4">✨</div>
+      <div class="flex justify-center mb-4"><%= app_icon("sparkles", css_class: "w-16 h-16 text-yellow-400") %></div>
       <p class="text-gray-600 text-lg mb-6">まだハレの記録がありません。<br>最初の一歩を踏み出しましょう！</p>
       <%= link_to "記録する", new_hare_entry_path, class: "bg-gradient-to-r from-orange-400 to-orange-300 text-white px-8 py-3 rounded-full font-semibold hover:from-orange-500 hover:to-orange-400 transition-colors shadow-md inline-block" %>
     </div>

--- a/app/views/hare_entries/new.html.erb
+++ b/app/views/hare_entries/new.html.erb
@@ -2,7 +2,7 @@
   <%# ページヘッダー %>
   <div class="mb-6">
     <h1 class="text-3xl font-bold text-gray-800 mb-2">今日のハレを記録する</h1>
-    <p class="text-gray-600">今日のごはんで「ちょっと特別」だったことを記録しましょう ✨</p>
+    <p class="text-gray-600 flex items-center gap-1">今日のごはんで「ちょっと特別」だったことを記録しましょう <%= app_icon("sparkles", css_class: "w-4 h-4 text-yellow-400") %></p>
   </div>
 
   <%# フォームカード %>

--- a/app/views/hare_entries/show.html.erb
+++ b/app/views/hare_entries/show.html.erb
@@ -9,7 +9,7 @@
     <%# ヘッダー情報 %>
     <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 mb-6 pb-4 border-b border-gray-100">
       <div class="flex items-center gap-3">
-        <span class="text-3xl">✨</span>
+        <%= app_icon("sparkles", css_class: "w-8 h-8 text-yellow-400") %>
         <p class="text-lg font-medium text-gray-700">
           <%= @hare_entry.occurred_on.strftime('%Y年%-m月%-d日') %>
         </p>
@@ -48,7 +48,7 @@
           <button data-action="click->clipboard#copy"
                   data-clipboard-target="button"
                   class="px-6 py-2.5 bg-blue-100 text-blue-700 rounded-full font-semibold hover:bg-blue-200 transition-colors">
-            🔗 共有URLをコピー
+            <%= app_icon("link", css_class: "w-4 h-4 inline-block") %> 共有URLをコピー
           </button>
           <span data-clipboard-target="feedback"
                 class="hidden ml-2 text-sm text-green-600 font-medium">コピーしました！</span>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -41,9 +41,9 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
         <%# かんたん献立カード（深緑） %>
         <div class="bg-[#7A9D7E] rounded-3xl p-5 md:p-8 shadow-lg relative overflow-hidden min-h-[200px] md:min-h-[240px] flex flex-col">
-          <%# 背景の丸（装飾）+ 絵文字 %>
+          <%# 背景の丸（装飾）+ アイコン %>
           <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-32 h-32 bg-white/10 rounded-full flex items-center justify-center">
-            <div class="text-5xl">🍚</div>
+            <div><%= app_icon("utensils", css_class: "w-14 h-14 text-white/80") %></div>
           </div>
 
           <div class="relative z-10 flex flex-col flex-1">
@@ -59,9 +59,9 @@
 
         <%# ハレ記録カード（オレンジ） %>
         <div class="bg-gradient-to-br from-[#D4845F] to-[#C97D5D] rounded-3xl p-5 md:p-8 shadow-lg relative overflow-hidden min-h-[200px] md:min-h-[240px] flex flex-col">
-          <%# 背景の丸（装飾）+ 絵文字 %>
+          <%# 背景の丸（装飾）+ アイコン %>
           <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-32 h-32 bg-white/10 rounded-full flex items-center justify-center">
-            <div class="text-5xl">✨</div>
+            <div><%= app_icon("sparkles", css_class: "w-14 h-14 text-white/80") %></div>
           </div>
 
           <div class="relative z-10 flex flex-col flex-1">
@@ -86,7 +86,7 @@
           <div class="space-y-3">
             <% @recent_hare_entries.each do |entry| %>
               <%= link_to hare_entry_path(entry), class: "flex items-start gap-3 p-3 rounded-xl hover:bg-gray-50 transition-colors block" do %>
-                <span class="text-xl mt-0.5">✨</span>
+                <%= app_icon("sparkles", css_class: "w-5 h-5 mt-0.5 text-yellow-400 flex-shrink-0") %>
                 <div class="flex-1 min-w-0">
                   <p class="text-sm text-gray-800 line-clamp-2"><%= entry.body.truncate(60) %></p>
                   <p class="text-xs text-gray-400 mt-1"><%= l(entry.occurred_on, format: :long) %></p>
@@ -128,7 +128,7 @@
       <%# ナビゲーションカード %>
       <div class="grid grid-cols-2 gap-3">
         <%= link_to hare_entries_path, class: "bg-white rounded-2xl p-4 flex items-center gap-3 shadow-sm hover:shadow-md transition-shadow" do %>
-          <span class="text-2xl">✨</span>
+          <%= app_icon("sparkles", css_class: "w-6 h-6 text-yellow-400 flex-shrink-0") %>
           <div class="flex-1">
             <p class="font-semibold text-sm text-gray-800">ハレ一覧</p>
             <p class="text-xs text-gray-400">過去の記録を見る</p>
@@ -137,7 +137,7 @@
         <% end %>
 
         <%= link_to meal_searches_path, class: "bg-white rounded-2xl p-4 flex items-center gap-3 shadow-sm hover:shadow-md transition-shadow" do %>
-          <span class="text-2xl">🍚</span>
+          <%= app_icon("utensils", css_class: "w-6 h-6 text-green-600 flex-shrink-0") %>
           <div class="flex-1">
             <p class="font-semibold text-sm text-gray-800">献立ログ</p>
             <p class="text-xs text-gray-400">相談履歴を見る</p>
@@ -146,7 +146,7 @@
         <% end %>
 
         <%= link_to new_chat_path, class: "bg-white rounded-2xl p-4 flex items-center gap-3 shadow-sm hover:shadow-md transition-shadow" do %>
-          <span class="text-2xl">🤖</span>
+          <%= app_icon("bot", css_class: "w-6 h-6 text-blue-500 flex-shrink-0") %>
           <div class="flex-1">
             <p class="font-semibold text-sm text-gray-800">AI相談</p>
             <p class="text-xs text-gray-400">料理の悩みを相談</p>
@@ -155,7 +155,7 @@
         <% end %>
 
         <%= link_to how_to_use_path, class: "bg-white rounded-2xl p-4 flex items-center gap-3 shadow-sm hover:shadow-md transition-shadow" do %>
-          <span class="text-2xl">📖</span>
+          <%= app_icon("book-open", css_class: "w-6 h-6 text-orange-400 flex-shrink-0") %>
           <div class="flex-1">
             <p class="font-semibold text-sm text-gray-800">使い方</p>
             <p class="text-xs text-gray-400">アプリの説明</p>
@@ -196,7 +196,7 @@
           <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
             <%# かんたん献立 %>
             <div class="bg-gradient-to-br from-[#7A9D7E] to-[#6B8D6E] rounded-3xl p-8 text-white shadow-lg">
-              <div class="text-5xl mb-4">🍚</div>
+              <div class="mb-4"><%= app_icon("utensils", css_class: "w-12 h-12 text-white/80") %></div>
               <h3 class="text-2xl font-bold mb-3">かんたん献立</h3>
               <p class="text-white/90 leading-relaxed">
                 「今日は何を作ろう？」そんな迷いを解決。
@@ -206,7 +206,7 @@
 
             <%# ハレ記録 %>
             <div class="bg-gradient-to-br from-[#D4845F] to-[#C97D5D] rounded-3xl p-8 text-white shadow-lg">
-              <div class="text-5xl mb-4">✨</div>
+              <div class="mb-4"><%= app_icon("sparkles", css_class: "w-12 h-12 text-white/80") %></div>
               <h3 class="text-2xl font-bold mb-3">ハレ記録</h3>
               <p class="text-white/90 leading-relaxed">
                 ちょっとした工夫や嬉しかったことを記録。
@@ -216,7 +216,7 @@
 
             <%# カレンダー %>
             <div class="bg-gradient-to-br from-[#E8A87C] to-[#D99B6E] rounded-3xl p-8 text-white shadow-lg">
-              <div class="text-5xl mb-4">📅</div>
+              <div class="mb-4"><%= app_icon("calendar", css_class: "w-12 h-12 text-white/80") %></div>
               <h3 class="text-2xl font-bold mb-3">ハレ度カレンダー</h3>
               <p class="text-white/90 leading-relaxed">
                 あなたの「ハレ度」を可視化。
@@ -236,7 +236,7 @@
           <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div class="bg-white rounded-2xl p-6 shadow-sm">
               <div class="flex items-start gap-4">
-                <div class="text-3xl">👨‍🍳</div>
+                <div><%= app_icon("chef-hat", css_class: "w-8 h-8 text-orange-500") %></div>
                 <div>
                   <h3 class="font-bold text-lg text-gray-900 mb-2">料理初心者の方</h3>
                   <p class="text-gray-700">献立の悩みを解決し、楽しく料理を続けられます。</p>
@@ -246,7 +246,7 @@
 
             <div class="bg-white rounded-2xl p-6 shadow-sm">
               <div class="flex items-start gap-4">
-                <div class="text-3xl">🏠</div>
+                <div><%= app_icon("house", css_class: "w-8 h-8 text-orange-500") %></div>
                 <div>
                   <h3 class="font-bold text-lg text-gray-900 mb-2">一人暮らしの方</h3>
                   <p class="text-gray-700">毎日の食事を記録し、自炊のモチベーションを維持。</p>
@@ -256,7 +256,7 @@
 
             <div class="bg-white rounded-2xl p-6 shadow-sm">
               <div class="flex items-start gap-4">
-                <div class="text-3xl">📈</div>
+                <div><%= app_icon("trending-up", css_class: "w-8 h-8 text-orange-500") %></div>
                 <div>
                   <h3 class="font-bold text-lg text-gray-900 mb-2">成長を実感したい方</h3>
                   <p class="text-gray-700">小さな工夫を積み重ね、「ハレ度」として可視化。</p>
@@ -266,7 +266,7 @@
 
             <div class="bg-white rounded-2xl p-6 shadow-sm">
               <div class="flex items-start gap-4">
-                <div class="text-3xl">💡</div>
+                <div><%= app_icon("lightbulb", css_class: "w-8 h-8 text-orange-500") %></div>
                 <div>
                   <h3 class="font-bold text-lg text-gray-900 mb-2">日常を楽しみたい方</h3>
                   <p class="text-gray-700">ちょっとした工夫で、毎日の食事が特別に。</p>

--- a/app/views/meal_guide/index.html.erb
+++ b/app/views/meal_guide/index.html.erb
@@ -2,14 +2,14 @@
   <%# ページヘッダー %>
   <div class="text-center mb-8">
     <h1 class="text-3xl font-bold text-gray-800 mb-2">どうやって相談する？</h1>
-    <p class="text-gray-600">2種類の献立サポートから選んでください 🍚</p>
+    <p class="text-gray-600 flex items-center justify-center gap-1">2種類の献立サポートから選んでください <%= app_icon("utensils", css_class: "w-5 h-5 text-green-600") %></p>
   </div>
 
   <%# 選択カード %>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
     <%# かんたん献立カード %>
     <div class="bg-[#7A9D7E] rounded-3xl p-6 md:p-8 shadow-lg flex flex-col min-h-[220px]">
-      <div class="text-4xl mb-3">📋</div>
+      <div class="mb-3"><%= app_icon("clipboard-list", css_class: "w-10 h-10 text-white/80") %></div>
       <h2 class="text-white text-xl font-bold mb-2">かんたん献立</h2>
       <p class="text-white/90 text-sm leading-relaxed mb-6 flex-1">
         フォームで条件（ジャンル・気分・時間）を選ぶと、おすすめの献立をすぐに提案します。
@@ -22,7 +22,7 @@
 
     <%# AI献立相談カード %>
     <div class="bg-gradient-to-br from-[#5B7FA6] to-[#4A6E95] rounded-3xl p-6 md:p-8 shadow-lg flex flex-col min-h-[220px]">
-      <div class="text-4xl mb-3">🤖</div>
+      <div class="mb-3"><%= app_icon("bot", css_class: "w-10 h-10 text-white/80") %></div>
       <h2 class="text-white text-xl font-bold mb-2">AI献立相談</h2>
       <p class="text-white/90 text-sm leading-relaxed mb-6 flex-1">
         AIと会話しながらじっくり相談。料理のアドバイスや食材の使い方も聞けます。

--- a/app/views/meal_searches/index.html.erb
+++ b/app/views/meal_searches/index.html.erb
@@ -12,7 +12,7 @@
   <% if @candidates.present? %>
     <div class="mb-12">
       <div class="flex items-center gap-2 mb-6">
-        <span class="text-2xl">🍳</span>
+        <%= app_icon("cooking-pot", css_class: "w-6 h-6 text-green-600") %>
         <h2 class="text-2xl font-bold text-gray-800">今回の提案</h2>
       </div>
       <div class="grid md:grid-cols-2 gap-4">
@@ -60,7 +60,7 @@
       </div>
     <% else %>
       <div class="text-center py-16 bg-white rounded-2xl shadow-sm">
-        <div class="text-5xl mb-4">🍚</div>
+        <div class="flex justify-center mb-4"><%= app_icon("utensils", css_class: "w-12 h-12 text-green-400") %></div>
         <p class="text-gray-600">まだかんたん献立のログがありません</p>
       </div>
     <% end %>

--- a/app/views/meal_searches/new.html.erb
+++ b/app/views/meal_searches/new.html.erb
@@ -3,7 +3,7 @@
   <div class="flex items-center justify-between mb-6">
     <div>
       <h1 class="text-3xl font-bold text-gray-800 mb-2">かんたん献立</h1>
-      <p class="text-gray-600">今日のごはん、何にしますか？ 🍚</p>
+      <p class="text-gray-600 flex items-center gap-1">今日のごはん、何にしますか？ <%= app_icon("utensils", css_class: "w-4 h-4 text-green-600") %></p>
     </div>
     <%= link_to "ホーム", home_path, class: "text-gray-600 hover:text-gray-800 font-medium" %>
   </div>
@@ -19,14 +19,14 @@
           <label class="flex-1 relative cursor-pointer">
             <%= f.radio_button :cook_context, "self_cook", class: "peer sr-only", data: { action: "change->meal-search-form#toggleMinutes" } %>
             <div class="flex items-center justify-center gap-2 px-4 py-3 sm:px-6 sm:py-4 bg-gray-50 peer-checked:bg-green-50 border-2 border-gray-200 peer-checked:border-green-400 rounded-xl transition-all">
-              <span class="text-2xl">🍳</span>
+              <%= app_icon("cooking-pot", css_class: "w-6 h-6 text-green-600") %>
               <span class="font-semibold text-gray-700 peer-checked:text-green-700">自炊する</span>
             </div>
           </label>
           <label class="flex-1 relative cursor-pointer">
             <%= f.radio_button :cook_context, "eat_out", class: "peer sr-only", data: { action: "change->meal-search-form#toggleMinutes" } %>
             <div class="flex items-center justify-center gap-2 px-4 py-3 sm:px-6 sm:py-4 bg-gray-50 peer-checked:bg-orange-50 border-2 border-gray-200 peer-checked:border-orange-400 rounded-xl transition-all">
-              <span class="text-2xl">🍽️</span>
+              <%= app_icon("utensils", css_class: "w-6 h-6 text-orange-500") %>
               <span class="font-semibold text-gray-700 peer-checked:text-orange-700">外で食べる</span>
             </div>
           </label>

--- a/app/views/meal_searches/redirect_to_maps.html.erb
+++ b/app/views/meal_searches/redirect_to_maps.html.erb
@@ -5,14 +5,14 @@
     <div class="flex items-center justify-between mb-6">
       <div>
         <h1 class="text-3xl font-bold text-gray-800 mb-2">かんたん献立</h1>
-        <p class="text-gray-600">今日のごはん、何にしますか？ 🍚</p>
+        <p class="text-gray-600 flex items-center gap-1">今日のごはん、何にしますか？ <%= app_icon("utensils", css_class: "w-4 h-4 text-green-600") %></p>
       </div>
       <%= link_to "ホーム", home_path, class: "text-gray-600 hover:text-gray-800 font-medium" %>
     </div>
 
     <%# メッセージカード %>
     <div class="bg-white rounded-2xl shadow-sm p-8 text-center">
-      <p class="text-2xl mb-2">🗺️</p>
+      <div class="flex justify-center mb-2"><%= app_icon("map", css_class: "w-8 h-8 text-orange-400") %></div>
       <h2 class="text-xl font-bold text-gray-800 mb-2">近くのお店を探しています...</h2>
       <p class="text-gray-600 mb-6">
         <span class="font-semibold text-orange-600"><%= @genre_label %></span> のお店を Google マップで検索します

--- a/app/views/messages/_assistant_message.html.erb
+++ b/app/views/messages/_assistant_message.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id(message) %>" class="flex items-start gap-2">
   <div class="w-8 h-8 rounded-full bg-gradient-to-br from-orange-400 to-yellow-300 flex items-center justify-center flex-shrink-0 mt-1">
-    <span class="text-sm">🤖</span>
+    <%= app_icon("bot", css_class: "w-4 h-4 text-white") %>
   </div>
   <div class="max-w-xs md:max-w-sm">
     <div class="bg-gray-100 rounded-2xl rounded-bl-sm px-4 py-3">
@@ -13,8 +13,8 @@
         <div class="mt-2 flex flex-col gap-1">
           <% dish_names.each do |dish_name| %>
             <%= link_to new_hare_entry_path(body: dish_name),
-                        class: "inline-block text-xs text-green-700 hover:text-green-900 border border-green-400 rounded-lg px-3 py-1.5 hover:bg-green-50 transition-colors" do %>
-              ✍️ <%= dish_name %>
+                        class: "inline-flex items-center gap-1 text-xs text-green-700 hover:text-green-900 border border-green-400 rounded-lg px-3 py-1.5 hover:bg-green-50 transition-colors" do %>
+              <%= app_icon("pen-line", css_class: "w-3 h-3") %> <%= dish_name %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/messages/_typing_indicator.html.erb
+++ b/app/views/messages/_typing_indicator.html.erb
@@ -1,7 +1,7 @@
 <%# AI が応答を生成中のタイピングインジケーター %>
 <div id="typing_indicator" class="flex items-start gap-2">
   <div class="w-8 h-8 rounded-full bg-gradient-to-br from-orange-400 to-yellow-300 flex items-center justify-center flex-shrink-0 mt-1">
-    <span class="text-sm">🤖</span>
+    <%= app_icon("bot", css_class: "w-4 h-4 text-white") %>
   </div>
   <div class="bg-gray-100 rounded-2xl rounded-bl-sm px-4 py-3">
     <span class="loading loading-dots loading-sm text-gray-400"></span>

--- a/app/views/pages/how_to_use.html.erb
+++ b/app/views/pages/how_to_use.html.erb
@@ -22,7 +22,7 @@
   <!-- 2. かんたん献立 -->
   <div class="card bg-white shadow-xl mb-6">
     <div class="card-body prose prose-gray max-w-none text-gray-900">
-      <h2>🍳 かんたん献立機能</h2>
+      <h2 class="flex items-center gap-2"><%= app_icon("cooking-pot", css_class: "w-6 h-6 text-orange-500") %> かんたん献立機能</h2>
       <p>「今日は何を食べよう？」そんなときは、かんたん献立を使ってみましょう。</p>
       <ol>
         <li><strong>食事のジャンルを選ぶ</strong>：和食、洋食、中華など、気分に合わせて選択</li>
@@ -38,7 +38,7 @@
   <!-- 3. ハレ投稿 -->
   <div class="card bg-white shadow-xl mb-6">
     <div class="card-body prose prose-gray max-w-none text-gray-900">
-      <h2>✨ ハレ投稿機能</h2>
+      <h2 class="flex items-center gap-2"><%= app_icon("sparkles", css_class: "w-6 h-6 text-yellow-400") %> ハレ投稿機能</h2>
       <p>「今日のごはん、ちょっと特別だったな」と思ったら、ハレ投稿で記録しましょう。</p>
       <ol>
         <li><strong>日付を選ぶ</strong>：今日のことでも、過去のことでもOK</li>
@@ -52,7 +52,7 @@
   <!-- 4. カレンダー -->
   <div class="card bg-white shadow-xl mb-6">
     <div class="card-body prose prose-gray max-w-none text-gray-900">
-      <h2>📅 カレンダー機能</h2>
+      <h2 class="flex items-center gap-2"><%= app_icon("calendar", css_class: "w-6 h-6 text-orange-400") %> カレンダー機能</h2>
       <p>投稿したハレは、カレンダーでスタンプとして表示されます。</p>
       <ul>
         <li><strong>1か月の記録が一目で分かる</strong>：「今月は何回ハレがあったかな？」</li>
@@ -65,7 +65,7 @@
   <!-- 5. ポイント・レベル -->
   <div class="card bg-white shadow-xl mb-6">
     <div class="card-body prose prose-gray max-w-none text-gray-900">
-      <h2>🎮 ポイントとレベル</h2>
+      <h2 class="flex items-center gap-2"><%= app_icon("gamepad-2", css_class: "w-6 h-6 text-orange-400") %> ポイントとレベル</h2>
       <p>ハレを投稿するとポイントが貯まり、レベルアップしていきます。</p>
       <ul>
         <li><strong>投稿1回で+1ポイント</strong></li>
@@ -81,7 +81,7 @@
   <!-- 6. 始め方 -->
   <div class="card bg-white shadow-xl mb-6">
     <div class="card-body prose prose-gray max-w-none text-gray-900">
-      <h2>🚀 始め方</h2>
+      <h2 class="flex items-center gap-2"><%= app_icon("rocket", css_class: "w-6 h-6 text-orange-400") %> 始め方</h2>
       <ol>
         <li><strong>アカウント登録</strong>：メールアドレスとパスワードで簡単登録</li>
         <li><strong>かんたん献立で今日のごはんを考える</strong>：気軽に試してみましょう</li>
@@ -103,7 +103,7 @@
   <!-- 7. FAQ -->
   <div class="card bg-white shadow-xl mb-6">
     <div class="card-body prose prose-gray max-w-none text-gray-900">
-      <h2>💡 よくある質問</h2>
+      <h2 class="flex items-center gap-2"><%= app_icon("lightbulb", css_class: "w-6 h-6 text-yellow-400") %> よくある質問</h2>
 
       <h3>Q1. 「ハレ」って、どのくらい特別じゃないとダメ？</h3>
       <p>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,7 +2,7 @@
   <%# ページヘッダー %>
   <div class="mb-8">
     <div class="flex items-center gap-3 mb-2">
-      <span class="text-4xl">👤</span>
+      <%= app_icon("user", css_class: "w-10 h-10 text-gray-600") %>
       <h1 class="text-2xl md:text-3xl font-bold text-gray-800">プロフィール</h1>
     </div>
     <p class="text-gray-600">あなたの情報と記録</p>
@@ -46,7 +46,7 @@
       <div class="flex items-center justify-between py-4 border-b border-gray-100">
         <span class="text-sm font-semibold text-gray-600">累計ポイント</span>
         <div class="flex items-center gap-2">
-          <span class="text-xl">✨</span>
+          <%= app_icon("sparkles", css_class: "w-5 h-5 text-yellow-400") %>
           <span class="text-lg font-semibold text-gray-800"><%= @user.point_transactions.sum(:points) %> pt</span>
         </div>
       </div>
@@ -55,7 +55,7 @@
       <div class="flex items-center justify-between py-4 border-b border-gray-100">
         <span class="text-sm font-semibold text-gray-600">総ハレ投稿数</span>
         <div class="flex items-center gap-2">
-          <span class="text-xl">🌸</span>
+          <%= app_icon("flower-2", css_class: "w-5 h-5 text-pink-400") %>
           <span class="text-lg font-semibold text-gray-800"><%= @user.hare_entries.count %> 件</span>
         </div>
       </div>

--- a/app/views/reflections/analyze.html.erb
+++ b/app/views/reflections/analyze.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="ai_analysis">
   <div class="bg-white rounded-2xl shadow-sm p-5">
-    <h2 class="text-sm font-semibold text-gray-700 mb-3">🤖 AI 傾向分析</h2>
+    <h2 class="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-1"><%= app_icon("bot", css_class: "w-4 h-4 text-blue-500") %> AI 傾向分析</h2>
     <div class="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed">
       <%= @analysis %>
     </div>

--- a/app/views/reflections/show.html.erb
+++ b/app/views/reflections/show.html.erb
@@ -1,7 +1,7 @@
 <main class="max-w-2xl mx-auto p-4 md:p-8">
   <div class="flex items-center justify-between mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-800 mb-1">📖 食生活レポート</h1>
+      <h1 class="text-2xl font-bold text-gray-800 mb-1 flex items-center gap-2"><%= app_icon("book-open", css_class: "w-6 h-6 text-orange-400") %> 食生活レポート</h1>
       <p class="text-gray-600 text-sm">直近30日間の記録から集計しています</p>
     </div>
     <%= link_to "ホーム", home_path, class: "text-gray-500 hover:text-gray-700 text-sm font-medium" %>
@@ -19,13 +19,13 @@
     </div>
     <div class="bg-white rounded-2xl shadow-sm p-4 text-center">
       <p class="text-3xl font-bold text-orange-500"><%= @stats.current_streak %><span class="text-lg font-bold">日</span></p>
-      <p class="text-xs text-gray-500 mt-1">🔥 連続記録</p>
+      <p class="text-xs text-gray-500 mt-1 flex items-center justify-center gap-0.5"><%= app_icon("flame", css_class: "w-3.5 h-3.5 text-orange-500") %> 連続記録</p>
     </div>
   </div>
 
   <%# タグランキング %>
   <div class="bg-white rounded-2xl shadow-sm p-5 mb-6">
-    <h2 class="text-sm font-semibold text-gray-700 mb-3">🏷️ よく使ったタグ TOP3</h2>
+    <h2 class="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-1"><%= app_icon("tag", css_class: "w-4 h-4 text-gray-600") %> よく使ったタグ TOP3</h2>
     <% if @stats.tag_ranking.empty? %>
       <p class="text-sm text-gray-400">まだタグをつけた記録がありません</p>
     <% else %>
@@ -57,13 +57,15 @@
   <%# AI分析 %>
   <turbo-frame id="ai_analysis">
     <div class="bg-white rounded-2xl shadow-sm p-5">
-      <h2 class="text-sm font-semibold text-gray-700 mb-3">🤖 AI 傾向分析</h2>
+      <h2 class="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-1"><%= app_icon("bot", css_class: "w-4 h-4 text-blue-500") %> AI 傾向分析</h2>
       <% if @stats.enough_data? %>
         <%# 分析ボタン %>
-        <%= button_to "✨ 分析を生成する", analyze_reflection_path,
+        <%= button_to analyze_reflection_path,
               method: :post,
-              class: "w-full bg-gradient-to-r from-blue-500 to-indigo-500 text-white py-3 rounded-xl font-semibold text-sm hover:from-blue-600 hover:to-indigo-600 transition-colors cursor-pointer",
-              data: { turbo_submits_with: "分析中..." } %>
+              class: "w-full bg-gradient-to-r from-blue-500 to-indigo-500 text-white py-3 rounded-xl font-semibold text-sm hover:from-blue-600 hover:to-indigo-600 transition-colors cursor-pointer inline-flex items-center justify-center gap-1.5",
+              data: { turbo_submits_with: "分析中..." } do %>
+          <%= app_icon("sparkles", css_class: "w-4 h-4") %> 分析を生成する
+        <% end %>
       <% else %>
         <%# データ不足: プログレスバー %>
         <div class="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-xl p-5">

--- a/app/views/share/hare_entries/show.html.erb
+++ b/app/views/share/hare_entries/show.html.erb
@@ -14,7 +14,7 @@
     <%# 投稿者・日付 %>
     <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 mb-6 pb-4 border-b border-gray-100">
       <div class="flex items-center gap-3">
-        <span class="text-3xl">✨</span>
+        <%= app_icon("sparkles", css_class: "w-8 h-8 text-yellow-400") %>
         <div>
           <p class="font-semibold text-gray-800"><%= @hare_entry.user.display_name %></p>
           <p class="text-sm text-gray-500"><%= @hare_entry.occurred_on.strftime('%Y年%-m月%-d日') %></p>


### PR DESCRIPTION
## 概要

- アプリ全体で使用していた24種類の絵文字（約70箇所）を Lucide SVG アイコンに置き換え
- `lucide-rails` gem を導入し、`ApplicationHelper` に `app_icon` ヘルパーを追加
- Tailwind CSS クラスでサイズ・色を統一

## 関連 Issue

closes #230

## 変更ファイル一覧

| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `Gemfile` / `Gemfile.lock` | 変更 | lucide-rails gem 追加 |
| `app/helpers/application_helper.rb` | 変更 | app_icon ヘルパー追加 |
| `app/views/home/index.html.erb` | 変更 | 13箇所置き換え |
| `app/views/chats/new.html.erb` | 変更 | 3箇所置き換え |
| `app/views/chats/show.html.erb` | 変更 | 4箇所置き換え |
| `app/views/hare_entries/index.html.erb` | 変更 | 2箇所置き換え |
| `app/views/hare_entries/show.html.erb` | 変更 | 2箇所置き換え |
| `app/views/hare_entries/new.html.erb` | 変更 | 1箇所置き換え |
| `app/views/hare_entries/edit.html.erb` | 変更 | 1箇所置き換え |
| `app/views/reflections/show.html.erb` | 変更 | 5箇所置き換え |
| `app/views/reflections/analyze.html.erb` | 変更 | 1箇所置き換え |
| `app/views/meal_guide/index.html.erb` | 変更 | 3箇所置き換え |
| `app/views/meal_searches/new.html.erb` | 変更 | 3箇所置き換え |
| `app/views/meal_searches/index.html.erb` | 変更 | 2箇所置き換え |
| `app/views/meal_searches/redirect_to_maps.html.erb` | 変更 | 2箇所置き換え |
| `app/views/messages/_assistant_message.html.erb` | 変更 | 2箇所置き換え |
| `app/views/messages/_typing_indicator.html.erb` | 変更 | 1箇所置き換え |
| `app/views/pages/how_to_use.html.erb` | 変更 | 6箇所置き換え |
| `app/views/profiles/show.html.erb` | 変更 | 3箇所置き換え |
| `app/views/calendar/index.html.erb` | 変更 | 1箇所置き換え |
| `app/views/calendar/show.html.erb` | 変更 | 3箇所置き換え |
| `app/views/share/hare_entries/show.html.erb` | 変更 | 1箇所置き換え |

## 実装のポイント

- `app_icon(name, css_class:, **options)` ラッパーで将来の変更に対応しやすくした
- `bowl-chopsticks` は lucide-rails v0.7.3 に未収録のため `utensils` で代替
- Twitter シェアテキスト内の `✨` は SNS 投稿文字列のため置き換えず保持
- サイズは用途別に統一: ナビ `w-6 h-6`、インライン `w-5 h-5`、ヒーロー `w-10〜w-14 h-10〜h-14`

## 残件・TODO

- lucide-rails のバージョンアップ時に `bowl-chopsticks` が使えるか再確認