### PR TITLE
[Fix] X シェアリンクの OGP 修正 + 導線追加

### DIFF
--- a/app/views/layouts/share.html.erb
+++ b/app/views/layouts/share.html.erb
@@ -5,15 +5,33 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= content_for?(:title) ? yield(:title) : "ケハレ帖" %></title>
 
-    <%# OGP メタタグ %>
-    <meta property="og:title" content="<%= content_for?(:og_title) ? yield(:og_title) : "ケハレ帖" %>">
-    <meta property="og:description" content="<%= content_for?(:og_description) ? yield(:og_description) : "日常の食事に小さなハレを" %>">
-    <meta property="og:type" content="article">
-    <meta property="og:url" content="<%= request.url %>">
-    <% if content_for?(:og_image) %>
-      <meta property="og:image" content="<%= yield(:og_image) %>">
-    <% end %>
-    <meta name="twitter:card" content="summary">
+    <%# meta description（SEO） %>
+    <meta name="description" content="<%= content_for?(:og_description) ? yield(:og_description) : "日常の食事に小さなハレを足す。毎日の食事記録アプリ「ケハレ帖」" %>">
+
+    <%# OGP（Open Graph Protocol） %>
+    <meta property="og:title"       content="<%= content_for?(:og_title) ? yield(:og_title) : "ケハレ帖" %>">
+    <meta property="og:description" content="<%= content_for?(:og_description) ? yield(:og_description) : "日常の食事に小さなハレを足す。毎日の食事記録アプリ「ケハレ帖」" %>">
+    <meta property="og:type"        content="article">
+    <meta property="og:url"         content="<%= request.original_url %>">
+    <meta property="og:image"       content="<%= content_for?(:og_image) ? yield(:og_image) : image_url("ogp.png") %>">
+    <meta property="og:site_name"   content="ケハレ帖">
+    <meta property="og:locale"      content="ja_JP">
+
+    <%# Twitter Card %>
+    <meta name="twitter:card"        content="summary_large_image">
+    <meta name="twitter:title"       content="<%= content_for?(:og_title) ? yield(:og_title) : "ケハレ帖" %>">
+    <meta name="twitter:description" content="<%= content_for?(:og_description) ? yield(:og_description) : "日常の食事に小さなハレを足す。毎日の食事記録アプリ「ケハレ帖」" %>">
+    <meta name="twitter:image"       content="<%= content_for?(:og_image) ? yield(:og_image) : image_url("ogp.png") %>">
+
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <link rel="icon" href="/icon.png" type="image/png">
+
+    <%# 和モダンフォント %>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic:wght@400;500;700&display=swap" rel="stylesheet">
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>

--- a/app/views/share/hare_entries/show.html.erb
+++ b/app/views/share/hare_entries/show.html.erb
@@ -1,13 +1,18 @@
 <% content_for :title, "#{@hare_entry.user.display_name}さんのハレ記録 | ケハレ帖" %>
 <% content_for :og_title, "#{@hare_entry.user.display_name}さんのハレ記録" %>
 <% content_for :og_description, @hare_entry.body.truncate(100) %>
+<% if @hare_entry.photo.attached? %>
+  <% content_for :og_image, cloudinary_photo_url(@hare_entry.photo, resize_to_limit: [1200, 630]) %>
+<% end %>
 
 <main class="max-w-2xl mx-auto px-4 pt-6 pb-8 font-zen">
   <%# ヘッダー %>
   <div class="text-center mb-8">
     <%= app_icon("flower-2", css_class: "w-8 h-8 text-[#C87941] inline-block mb-2") %>
-    <h1 class="text-2xl font-bold text-[#4A4036]">ケハレ帖</h1>
-    <p class="text-sm text-[#8D7B68] mt-1">日常の食事に小さなハレを</p>
+    <%= link_to root_path, class: "block" do %>
+      <h1 class="text-2xl font-bold text-[#4A4036]">ケハレ帖</h1>
+      <p class="text-sm text-[#8D7B68] mt-1">日常の食事に小さなハレを</p>
+    <% end %>
   </div>
 
   <%# 投稿カード %>
@@ -57,8 +62,28 @@
       class: "px-6 py-2.5 bg-[#4A4036] text-white rounded-full font-semibold hover:bg-[#2E2820] transition-colors shadow-sm" %>
   </div>
 
+  <%# CTA セクション %>
+  <div class="mt-10 bg-[#FFFCF5] rounded-3xl border border-[#E8E0D0] shadow-sm p-6 text-center">
+    <p class="text-sm text-[#8D7B68] mb-1">あなたも記録してみませんか？</p>
+    <p class="text-lg font-bold text-[#4A4036] mb-5">毎日の食事に、小さなハレを</p>
+    <div class="flex flex-col sm:flex-row gap-3 justify-center">
+      <%= link_to "新規登録（無料）", new_user_registration_path,
+        class: "px-6 py-3 bg-gradient-to-r from-[#C87941] to-[#E8A87C] text-white rounded-full font-semibold hover:opacity-90 transition-opacity shadow-sm" %>
+      <%= link_to "ログイン", new_user_session_path,
+        class: "px-6 py-3 bg-white border border-[#C87941] text-[#C87941] rounded-full font-semibold hover:bg-orange-50 transition-colors" %>
+    </div>
+    <div class="mt-4">
+      <%= link_to "みんなのハレを見る →", public_hare_entries_path,
+        class: "text-sm text-[#8D7B68] hover:text-[#C87941] underline transition-colors" %>
+    </div>
+  </div>
+
   <%# フッター %>
-  <div class="text-center mt-6 text-sm text-[#8D7B68]">
+  <div class="text-center mt-6 text-sm text-[#8D7B68] space-y-2">
     <p>ケハレ帖 — 日常の食事に小さなハレを</p>
+    <div class="flex justify-center gap-4">
+      <%= link_to "使い方", how_to_use_path, class: "hover:text-[#C87941] transition-colors" %>
+      <%= link_to "プライバシーポリシー", privacy_policy_path, class: "hover:text-[#C87941] transition-colors" %>
+    </div>
   </div>
 </main>

--- a/spec/requests/share/hare_entries_spec.rb
+++ b/spec/requests/share/hare_entries_spec.rb
@@ -21,6 +21,55 @@ RSpec.describe "Share::HareEntries", type: :request do
         get share_hare_entry_path(public_entry.share_token)
         expect(response.body).to include(user.display_name)
       end
+
+      it "OGP タイトルを出力すること" do
+        get share_hare_entry_path(public_entry.share_token)
+        expect(response.body).to include('property="og:title"')
+        expect(response.body).to include(user.display_name)
+      end
+
+      it "og:description を出力すること" do
+        get share_hare_entry_path(public_entry.share_token)
+        expect(response.body).to include('property="og:description"')
+      end
+
+      it "og:image にフォールバック画像を出力すること" do
+        get share_hare_entry_path(public_entry.share_token)
+        expect(response.body).to include('property="og:image"')
+        # アセットフィンガープリント付き（例: ogp-abc123.png）に対応
+        expect(response.body).to match(/og:image.*ogp/)
+      end
+
+      it "twitter:card を summary_large_image で出力すること" do
+        get share_hare_entry_path(public_entry.share_token)
+        expect(response.body).to include('name="twitter:card"')
+        expect(response.body).to include("summary_large_image")
+      end
+
+      it "twitter:title を出力すること" do
+        get share_hare_entry_path(public_entry.share_token)
+        expect(response.body).to include('name="twitter:title"')
+      end
+
+      it "twitter:image を出力すること" do
+        get share_hare_entry_path(public_entry.share_token)
+        expect(response.body).to include('name="twitter:image"')
+      end
+
+      it "新規登録リンクを表示すること" do
+        get share_hare_entry_path(public_entry.share_token)
+        expect(response.body).to include(new_user_registration_path)
+      end
+
+      it "ログインリンクを表示すること" do
+        get share_hare_entry_path(public_entry.share_token)
+        expect(response.body).to include(new_user_session_path)
+      end
+
+      it "みんなのハレリンクを表示すること" do
+        get share_hare_entry_path(public_entry.share_token)
+        expect(response.body).to include(public_hare_entries_path)
+      end
     end
 
     context "非公開投稿の share_token にアクセスした場合" do


### PR DESCRIPTION
## 概要
X (Twitter) でハレ記録をシェアした際の OGP 不具合と導線欠如を修正する。

## 関連 Issue
closes #247

## 変更ファイル一覧
| ファイル | 種別 | 変更理由 |
|---------|------|---------|
| `app/views/layouts/share.html.erb` | 修正 | OGP・Twitter Card 完全実装 |
| `app/views/share/hare_entries/show.html.erb` | 修正 | og:image 動的設定 + CTA 導線追加 |
| `spec/requests/share/hare_entries_spec.rb` | 修正 | OGP・CTA テスト追加 |

## 実装のポイント

### share レイアウトの OGP 修正
- `og:image` にフォールバック（`image_url("ogp.png")`）を追加（条件なしで常に出力）
- `twitter:card` を `summary` から `summary_large_image` に変更
- `twitter:title`, `twitter:image`, `twitter:description` を新規追加
- `og:site_name`, `og:locale`, `meta name="description"` を追加
- `request.url` から `request.original_url` に統一
- `csrf_meta_tags`, `csp_meta_tag`, Google Fonts を追加

### show ビューの強化
- 写真あり時に `cloudinary_photo_url` で 1200x630 の og:image を動的設定
- ヘッダーのロゴを `root_path` リンクに変更
- 新規登録・ログイン・みんなのハレ への CTA セクションを追加
- フッターに使い方・プライバシーポリシーリンクを追加

## テスト計画
- [x] OGP メタタグ（og:title, og:description, og:image）の出力確認
- [x] Twitter Card（twitter:card = summary_large_image, twitter:title, twitter:image）確認
- [x] 新規登録・ログイン・みんなのハレへの CTA 表示確認
- [x] 全 14 テストが通過

## 残件・TODO
- `app/assets/images/ogp.png` が 7.4MB のため圧縮を推奨（別作業）
  - 推奨: 1200x630px、200-500KB 以下
  - SNS クローラーのタイムアウト防止のため対応を検討