### PR TITLE
[Fix] カレンダーボタンの "Content missing" を修正（Turbo Frame 対応）

### DIFF
--- a/app/views/calendar/_entry_detail.html.erb
+++ b/app/views/calendar/_entry_detail.html.erb
@@ -64,11 +64,13 @@
     <%# ボタン %>
     <div class="flex justify-center gap-3 pt-4">
       <%= link_to hare_entry_path(entry),
+          data: { turbo_frame: "_top" },
           class: "flex items-center gap-2 px-6 py-2.5 bg-[#8D7B68] hover:bg-[#776E60] text-white rounded-full shadow-md hover:-translate-y-0.5 transition-all font-bold text-sm" do %>
         <%= app_icon("notebook-pen", css_class: "w-4 h-4") %>
         全文を見る
       <% end %>
       <%= link_to edit_hare_entry_path(entry),
+          data: { turbo_frame: "_top" },
           class: "flex items-center gap-2 px-6 py-2.5 bg-[#FFFCF5] hover:bg-[#FFF0D4] text-[#8D7B68] hover:text-[#C87941] rounded-full shadow-sm border border-[#E8E0D0] hover:border-[#C87941] hover:-translate-y-0.5 transition-all font-bold text-sm" do %>
         <%= app_icon("pencil", css_class: "w-4 h-4") %>
         編集

--- a/app/views/calendar/_entry_empty.html.erb
+++ b/app/views/calendar/_entry_empty.html.erb
@@ -7,6 +7,7 @@
     <p class="text-[#4A4036] text-lg font-semibold mb-1">この日はまだハレがありません</p>
     <p class="text-[#B8AFA5] text-sm mb-6">小さな「ちょっと特別」を記録してみましょう</p>
     <%= link_to new_hare_entry_path,
+        data: { turbo_frame: "_top" },
         class: "btn bg-gradient-to-r from-[#C87941] to-[#E8A87C] text-white border-0 rounded-full shadow-md hover:shadow-lg hover:-translate-y-0.5 transition-all font-bold" do %>
       <%= app_icon("plus", css_class: "w-4 h-4 mr-1") %> ハレを記録する
     <% end %>


### PR DESCRIPTION
## 概要
カレンダー右パネルの「全文を見る」「編集」「ハレを記録する」ボタンを押すと "Content missing" になっていた問題を修正。

## 原因
`calendar/show.html.erb` の `<turbo-frame id="calendar-detail">` 内でリンクをクリックすると、Turbo は遷移先ページに同じ `id="calendar-detail"` のフレームを探す。`hare_entries#show` / `hare_entries#edit` / `hare_entries#new` にはそのフレームが存在しないため "Content missing" が表示されていた。

## 修正内容
対象リンクに `data: { turbo_frame: "_top" }` を付与し、フレーム内遷移ではなく全画面ナビゲーションに変更。

| ファイル | 修正箇所 |
|---------|---------|
| `app/views/calendar/_entry_detail.html.erb` | 「全文を見る」「編集」ボタン |
| `app/views/calendar/_entry_empty.html.erb` | 「ハレを記録する」ボタン |

## 動作確認
- [x] 「全文を見る」→ `hare_entries#show` に全画面遷移
- [x] 「編集」→ `hare_entries#edit` に全画面遷移
- [x] 「ハレを記録する」→ `hare_entries#new` に全画面遷移

## 残件・TODO
- なし